### PR TITLE
updated method for setting security-context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ testbin/*
 *.swp
 *.swo
 *~
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.5)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 .PHONY: envtest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,11 +21,12 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
-        seccomp.security.alpha.kubernetes.io/pod: runtime/default
       labels:
         control-plane: controller-manager
     spec:
       securityContext:
+        seccompProfile:
+          type: RuntimeDefault
         runAsNonRoot: true
         fsGroup: 150
         supplementalGroups:

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -264,8 +264,7 @@ func (reconciler *ApplicationReconciler) addDeploymentData(ctx context.Context, 
 			MatchLabels: labels,
 		}
 		deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{
-			"prometheus.io/scrape":                     "true",
-			"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
+			"prometheus.io/scrape": "true",
 		}
 		deployment.Spec.Template.Spec.Containers = make([]v1.Container, 1)
 		deployment.Spec.Template.Spec.Containers[0].Ports = make([]v1.ContainerPort, 1)
@@ -299,6 +298,7 @@ func (reconciler *ApplicationReconciler) addDeploymentData(ctx context.Context, 
 	deployment.Spec.Template.Spec.Containers[0].Image = app.Spec.Image
 	deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = v1.PullAlways
 
+	deployment.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile.Type = "runtime/default"
 	deployment.Spec.Template.Spec.Containers[0].SecurityContext.Privileged = &no
 	deployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation = &no
 	deployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = &yes

--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -298,7 +298,10 @@ func (reconciler *ApplicationReconciler) addDeploymentData(ctx context.Context, 
 	deployment.Spec.Template.Spec.Containers[0].Image = app.Spec.Image
 	deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = v1.PullAlways
 
-	deployment.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile.Type = "runtime/default"
+	if deployment.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile == nil {
+		deployment.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile = &v1.SeccompProfile{}
+	}
+	deployment.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile.Type = "RuntimeDefault"
 	deployment.Spec.Template.Spec.Containers[0].SecurityContext.Privileged = &no
 	deployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation = &no
 	deployment.Spec.Template.Spec.Containers[0].SecurityContext.ReadOnlyRootFilesystem = &yes


### PR DESCRIPTION
Note: The functional support for the already deprecated seccomp annotations seccomp.security.alpha.kubernetes.io/pod (for the whole pod) and container.seccomp.security.alpha.kubernetes.io/[name] (for a single container) is going to be removed with the release of Kubernetes v1.25. Please always use the native API fields in favor of the annotations. 

Oppdatert for bruk av den nye metoden for å sette securityContext siden annotation er på vei ut. Fra det jeg så var dette eneste stedet det settes i skiperator