### PR TITLE
Fix order of arguments

### DIFF
--- a/deployment/deployment.tf
+++ b/deployment/deployment.tf
@@ -25,7 +25,7 @@ resource "kubernetes_deployment_v1" "deployment" {
         container {
           name  = "skiperator"
           image = var.image
-          args  = ["-l", "-d", "-t", "$(IMAGE_PULL_TOKEN)"]
+          args  = ["-l", "-d", "-t=$(IMAGE_PULL_TOKEN)"]
           env {
             name = "IMAGE_PULL_TOKEN"
             value_from {


### PR DESCRIPTION
I put the -d flag by mistake after -t which expects a string argument.

Set the -t flag and value as a single argument instead.