### PR TITLE
Drop some istio metrics by default in monitor objects

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -321,6 +321,13 @@ type PrometheusConfig struct {
 	//+kubebuilder:default:=/metrics
 	//+kubebuilder:validation:Optional
 	Path string `json:"path,omitempty"`
+
+	// Setting AllowAllMetrics to true will ensure all exposed metrics are scraped. Otherwise, a list of predefined
+	// metrics will be dropped by default. See util/constants.go for the default list.
+	//
+	//+kubebuilder:default:=false
+	//+kubebuilder:validation:Optional
+	AllowAllMetrics bool `json:"allowAllMetrics,omitempty"`
 }
 
 // ApplicationStatus

--- a/api/v1alpha1/skipjob_types.go
+++ b/api/v1alpha1/skipjob_types.go
@@ -65,7 +65,7 @@ type SKIPJobSpec struct {
 	Container ContainerSettings `json:"container"`
 
 	// Prometheus settings for pod running in job. Fields are identical to Application and if set,
-	// a monitorngs object is created.
+	// a podmonitoring object is created.
 	Prometheus *PrometheusConfig `json:"prometheus,omitempty"`
 }
 

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -773,6 +773,12 @@ spec:
                 description: Optional settings for how Prometheus compatible metrics
                   should be scraped.
                 properties:
+                  allowAllMetrics:
+                    default: false
+                    description: |-
+                      Setting AllowAllMetrics to true will ensure all exposed metrics are scraped. Otherwise, a list of predefined
+                      metrics will be dropped by default. See util/constants.go for the default list.
+                    type: boolean
                   path:
                     default: /metrics
                     description: The HTTP path where Prometheus compatible metrics

--- a/config/crd/skiperator.kartverket.no_skipjobs.yaml
+++ b/config/crd/skiperator.kartverket.no_skipjobs.yaml
@@ -721,6 +721,12 @@ spec:
                   Prometheus settings for pod running in job. Fields are identical to Application and if set,
                   a monitorngs object is created.
                 properties:
+                  allowAllMetrics:
+                    default: false
+                    description: |-
+                      Setting AllowAllMetrics to true will ensure all exposed metrics are scraped. Otherwise, a list of predefined
+                      metrics will be dropped by default. See util/constants.go for the default list.
+                    type: boolean
                   path:
                     default: /metrics
                     description: The HTTP path where Prometheus compatible metrics

--- a/controllers/application/service_monitor.go
+++ b/controllers/application/service_monitor.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"strings"
 )
 
 func (r *ApplicationReconciler) reconcileServiceMonitor(ctx context.Context, application *skiperatorv1alpha1.Application) (reconcile.Result, error) {
@@ -67,6 +68,16 @@ func (r *ApplicationReconciler) reconcileServiceMonitor(ctx context.Context, app
 					TargetPort: &util.IstioMetricsPortName,
 				},
 			},
+		}
+
+		if !application.Spec.Prometheus.AllowAllMetrics {
+			serviceMonitor.Spec.Endpoints[0].MetricRelabelConfigs = []*pov1.RelabelConfig{
+				{
+					Action:       "drop",
+					Regex:        strings.Join(util.DefaultMetricDropList, "|"),
+					SourceLabels: []pov1.LabelName{"__name__"},
+				},
+			}
 		}
 
 		return nil

--- a/controllers/skipjob/pod_monitor.go
+++ b/controllers/skipjob/pod_monitor.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"strings"
 )
 
 func (r *SKIPJobReconciler) reconcilePodMonitor(ctx context.Context, skipJob *skiperatorv1alpha1.SKIPJob) (reconcile.Result, error) {
@@ -49,6 +50,15 @@ func (r *SKIPJobReconciler) reconcilePodMonitor(ctx context.Context, skipJob *sk
 					TargetPort: &util.IstioMetricsPortName,
 				},
 			},
+		}
+		if !skipJob.Spec.Prometheus.AllowAllMetrics {
+			podMonitor.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs = []*pov1.RelabelConfig{
+				{
+					Action:       "drop",
+					Regex:        strings.Join(util.DefaultMetricDropList, "|"),
+					SourceLabels: []pov1.LabelName{"__name__"},
+				},
+			}
 		}
 		return nil
 	})

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -20,6 +20,12 @@ var (
 	IstioMetricsPath       = "/stats/prometheus"
 
 	IstioRevisionLabel = "istio.io/rev"
+
+	DefaultMetricDropList = []string{
+		"istio_request_bytes_bucket",
+		"istio_response_bytes_bucket",
+		"istio_request_duration_milliseconds_bucket",
+	}
 )
 
 // A security context for use in pod containers created by Skiperator

--- a/tests/application/service-monitor/application-istio-assert.yaml
+++ b/tests/application/service-monitor/application-istio-assert.yaml
@@ -68,6 +68,11 @@ spec:
   endpoints:
     - targetPort: istio-metrics
       path: /stats/prometheus
+      metricRelabelings:
+      - action: drop
+        regex: istio_request_bytes_bucket|istio_response_bytes_bucket|istio_request_duration_milliseconds_bucket
+        sourceLabels:
+        - __name__
   selector:
     matchLabels:
       app: some-monitored-app-1

--- a/tests/application/service-monitor/chainsaw-test.yaml
+++ b/tests/application/service-monitor/chainsaw-test.yaml
@@ -13,3 +13,8 @@ spec:
             file: application-istio.yaml
         - assert:
             file: application-istio-assert.yaml
+    - try:
+        - patch:
+            file: patch-application-allowall.yaml
+        - assert:
+            file: patch-application-allowall-assert.yaml

--- a/tests/application/service-monitor/patch-application-allowall-assert.yaml
+++ b/tests/application/service-monitor/patch-application-allowall-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    instance: primary
+  name: some-monitored-app-1
+  namespace: sm-istio-ns
+spec:
+  endpoints:
+    - targetPort: istio-metrics
+      path: /stats/prometheus
+  selector:
+    matchLabels:
+      app: some-monitored-app-1
+  namespaceSelector:
+    matchNames:
+      - sm-istio-ns

--- a/tests/application/service-monitor/patch-application-allowall.yaml
+++ b/tests/application/service-monitor/patch-application-allowall.yaml
@@ -1,0 +1,15 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: some-monitored-app-1
+  namespace: sm-istio-ns
+spec:
+  image: image
+  port: 8080
+  additionalPorts:
+    - name: metrics
+      port: 8181
+      protocol: TCP
+  prometheus:
+    port: metrics
+    allowAllMetrics: true

--- a/tests/skipjob/podmonitor/chainsaw-test.yaml
+++ b/tests/skipjob/podmonitor/chainsaw-test.yaml
@@ -13,6 +13,11 @@ spec:
             file: skipjob-with-monitoring.yaml
         - assert:
             file: skipjob-with-monitoring-assert.yaml
+    - try:
+        - patch:
+            file: patch-skipjob-with-monitoring.yaml
+        - assert:
+            file: patch-skipjob-with-monitoring-assert.yaml
         - delete:
             ref:
               apiVersion: skiperator.kartverket.no/v1alpha1

--- a/tests/skipjob/podmonitor/patch-skipjob-with-monitoring-assert.yaml
+++ b/tests/skipjob/podmonitor/patch-skipjob-with-monitoring-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    instance: primary
+  name: podmonitor-monitor
+spec:
+  namespaceSelector:
+    matchNames:
+      - podmonitor-ns
+  podMetricsEndpoints:
+    - targetPort: istio-metrics
+      path: "/stats/prometheus"
+  selector:
+    matchLabels:
+      app: podmonitor

--- a/tests/skipjob/podmonitor/patch-skipjob-with-monitoring.yaml
+++ b/tests/skipjob/podmonitor/patch-skipjob-with-monitoring.yaml
@@ -1,0 +1,16 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: SKIPJob
+metadata:
+  name: podmonitor
+spec:
+  container:
+    image: "perl:5.34.0"
+    command:
+      - "perl"
+      - "-Mbignum=bpi"
+      - "-wle"
+      - "print bpi(2000)"
+  prometheus:
+    path: /metrics
+    port: 8080
+    allowAllMetrics: true

--- a/tests/skipjob/podmonitor/skipjob-with-monitoring-assert.yaml
+++ b/tests/skipjob/podmonitor/skipjob-with-monitoring-assert.yaml
@@ -55,6 +55,11 @@ spec:
   podMetricsEndpoints:
     - targetPort: istio-metrics
       path: "/stats/prometheus"
+      metricRelabelings:
+        - action: drop
+          regex: istio_request_bytes_bucket|istio_response_bytes_bucket|istio_request_duration_milliseconds_bucket
+          sourceLabels:
+            - __name__
   selector:
     matchLabels:
       app: podmonitor


### PR DESCRIPTION
Collecting all istio metrics for all applications produces a lot of waste if not used.
Because some product teams might want to use them we should make it possible to opt in by setting `AllowAllMetrics` to `true`.

Open for suggestions on other ways to accomplish this ☺️ 