### PR TITLE
SKIP-1704: hide feature behind toggle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ export IMAGE_PULL_0_REGISTRY := ghcr.io
 export IMAGE_PULL_1_REGISTRY := https://index.docker.io/v1/
 export IMAGE_PULL_0_TOKEN :=
 export IMAGE_PULL_1_TOKEN :=
+export CLUSTER_CIDR_EXCLUDE := true
 test: install-test-tools install-skiperator
 	@./bin/chainsaw test --kube-context $(SKIPERATOR_CONTEXT) --config tests/config.yaml --test-dir tests/ && \
     echo "Test succeeded" || (echo "Test failed" && exit 1)
@@ -130,6 +131,7 @@ export IMAGE_PULL_0_REGISTRY := ghcr.io
 export IMAGE_PULL_1_REGISTRY := https://index.docker.io/v1/
 export IMAGE_PULL_0_TOKEN :=
 export IMAGE_PULL_1_TOKEN :=
+export CLUSTER_CIDR_EXCLUDE := true
 run-test: build
 	@echo "Starting skiperator in background..."
 	@LOG_FILE=$$(mktemp -t skiperator-test.XXXXXXX); \

--- a/cmd/skiperator/main.go
+++ b/cmd/skiperator/main.go
@@ -127,12 +127,18 @@ func main() {
 	// as this configmap contains the CIDRs for cluster nodes in order to prevent egress traffic
 	// directly from namespaces as per SKIP-1704
 
-	configCheckClient, err := client.New(kubeconfig, client.Options{})
-
-	skipClusterList, err := config.LoadConfigFromConfigMap(configCheckClient)
-	if err != nil {
-		setupLog.Error(err, "could not load SKIP cluster config")
-		os.Exit(1)
+	var skipClusterList *config.SKIPClusterList
+	if cfg.ClusterCIDRExclusionEnabled {
+		configCheckClient, err := client.New(kubeconfig, client.Options{})
+		skipClusterList, err = config.LoadConfigFromConfigMap(configCheckClient)
+		if err != nil {
+			setupLog.Error(err, "could not load SKIP cluster config")
+			os.Exit(1)
+		}
+	} else {
+		skipClusterList = &config.SKIPClusterList{
+			Clusters: []*config.SKIPCluster{},
+		}
 	}
 
 	err = (&controllers.SKIPJobReconciler{

--- a/pkg/envconfig/env.go
+++ b/pkg/envconfig/env.go
@@ -5,5 +5,6 @@ type RegistryCredentialPair struct {
 	Token    string `env:"TOKEN"`
 }
 type Vars struct {
-	RegistryCredentials []RegistryCredentialPair `envPrefix:"IMAGE_PULL"`
+	RegistryCredentials         []RegistryCredentialPair `envPrefix:"IMAGE_PULL"`
+	ClusterCIDRExclusionEnabled bool                     `env:"CLUSTER_CIDR_EXCLUDE" envDefault:"false"`
 }


### PR DESCRIPTION
Hides the feature introduced in SKIP-1704 behind a toggle, so we can roll it out at a later date after the summer holidays are over.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enabling or disabling cluster CIDR exclusion via a new environment variable. When enabled, the application conditionally loads cluster configuration based on this setting.

* **Chores**
  * Updated test commands to set the new environment variable automatically during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->