### PR TITLE
remove pr trigger from build-and-deploy workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -9,13 +9,6 @@ on:
       - samples/**
       - README.md
       - CONTRIBUTING.md
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - doc/**
-      - samples/**
-      - README.md
-      - CONTRIBUTING.md
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -62,7 +55,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ !github.event.pull_request.draft }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -72,7 +65,6 @@ jobs:
       image_digest: ${{ steps.build-docker.outputs.digest }}
 
   pharos-scan:
-    if: (!github.event.pull_request.draft)
     name: Run Pharos Security Scan
     needs: build
     runs-on: ubuntu-latest
@@ -89,7 +81,6 @@ jobs:
           tfsec: false
 
   generate:
-    if: (!github.event.pull_request.draft)
     name: CRD and ClusterRole
     runs-on: ubuntu-latest
     permissions:
@@ -117,7 +108,6 @@ jobs:
             ${{ env.CRD_ROUTING_FILE_PATH }}
 
   deploy-argo:
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
     needs: [build, generate]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
SKIP-1752

skiperator is seemingly (one of) the only repo that builds, pushed and runs pharos scan on pull_request (and every push on branch with PR). is this necessary? 
this PR shifts to only trigger build, push and scan on push to main which matches existing schedule for release to sandbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized CI/CD behavior: build, scan, generate, and deployment steps now run consistently for both pushes and pull requests.
  - Docker images are always pushed during builds, removing prior conditional gating.
  - Eliminated draft PR and path-based restrictions in the workflow.

- **Notes**
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->