### PR TITLE
add cel rule thats disallows 'app'

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -227,6 +227,7 @@ type ApplicationSpec struct {
 	// Any amount of labels can be added as wanted, and they will all cascade down to all resources.
 	//
 	//+kubebuilder:validation:Optional
+	//+kubebuilder:validation:XValidation:rule="!self.exists(k, k == 'app')", message="The label key \"app\" is reserved and cannot be used as a label."
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// ResourceLabels can be used if you want to add a label to a specific resources created by

--- a/api/v1alpha1/skipjob_types.go
+++ b/api/v1alpha1/skipjob_types.go
@@ -100,6 +100,7 @@ type SKIPJobSpec struct {
 	// Any amount of labels can be added as wanted, and they will all cascade down to all resources.
 	//
 	//+kubebuilder:validation:Optional
+	//+kubebuilder:validation:XValidation:rule="!self.exists(k, k == 'app')", message="The label key \"app\" is reserved and cannot be used as a label."
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Team specifies the team who owns this particular SKIPJob.

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -891,6 +891,10 @@ spec:
                   metrics, where a certain label and the corresponding resources liveliness can be combined.
                   Any amount of labels can be added as wanted, and they will all cascade down to all resources.
                 type: object
+                x-kubernetes-validations:
+                - message: The label key "app" is reserved and cannot be used as a
+                    label.
+                  rule: '!self.exists(k, k == ''app'')'
               liveness:
                 description: |-
                   Liveness probes define a resource that returns 200 OK when the app is running

--- a/config/crd/skiperator.kartverket.no_skipjobs.yaml
+++ b/config/crd/skiperator.kartverket.no_skipjobs.yaml
@@ -919,6 +919,10 @@ spec:
                   metrics, where a certain label and the corresponding resources liveliness can be combined.
                   Any amount of labels can be added as wanted, and they will all cascade down to all resources.
                 type: object
+                x-kubernetes-validations:
+                - message: The label key "app" is reserved and cannot be used as a
+                    label.
+                  rule: '!self.exists(k, k == ''app'')'
               prometheus:
                 description: |-
                   Prometheus settings for pod running in job. Fields are identical to Application and if set,

--- a/tests/application/labels/chainsaw-test.yaml
+++ b/tests/application/labels/chainsaw-test.yaml
@@ -1,0 +1,50 @@
+# Checks if labels "app" as key are rejected in the manifest spec, due to bug with selectors of subresources.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: reject-app-label
+spec:
+  skip: false
+  concurrent: true
+  skipDelete: false
+  steps:
+    - try:
+        - script:
+            env:
+              - name: TEST_NS
+                value: ($namespace)
+            content: |
+              kubectl apply -f - <<EOF
+                apiVersion: skiperator.kartverket.no/v1alpha1
+                kind: Application
+                metadata:
+                  name: app-label
+                  namespace: $TEST_NS
+                spec:
+                  image: image
+                  port: 8080
+                  labels:
+                    app: test
+              EOF
+            check:
+              ($error != null): true
+              '(contains($stderr, ''The label key "app" is reserved and cannot be used as a label.''))': true
+        - script:
+            env:
+              - name: TEST_NS
+                value: ($namespace)
+            content: |
+              kubectl apply -f - <<EOF
+                apiVersion: skiperator.kartverket.no/v1alpha1
+                kind: Application
+                metadata:
+                  name: app-label
+                  namespace: $TEST_NS
+                spec:
+                  image: image
+                  port: 8080
+                  labels:
+                    test: app
+              EOF
+            check:
+              ($error == null): true

--- a/tests/skipjob/skipjob-label/chainsaw-test.yaml
+++ b/tests/skipjob/skipjob-label/chainsaw-test.yaml
@@ -26,7 +26,7 @@ spec:
                   namespace: $TEST_NS
                 spec:
                   container:
-                    image: "imag"e
+                    image: image
                   labels:
                     app: test-label
               EOF

--- a/tests/skipjob/skipjob-label/chainsaw-test.yaml
+++ b/tests/skipjob/skipjob-label/chainsaw-test.yaml
@@ -1,4 +1,4 @@
-apiVersion: chainsaw.kyverno.io/v1alpha1  
+apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
   name: skipjob-label
@@ -6,14 +6,33 @@ spec:
   skip: false
   concurrent: true
   skipDelete: false
-  
+
   steps:
     - try:
         - apply:
             file: skipjob.yaml
         - assert:
             file: skipjob-assert.yaml
-
+        - script:
+            env:
+              - name: TEST_NS
+                value: ($namespace)
+            content: |
+              kubectl apply -f - <<EOF
+                apiVersion: skiperator.kartverket.no/v1alpha1
+                kind: SKIPJob
+                metadata:
+                  name: skipjob-app-label
+                  namespace: $TEST_NS
+                spec:
+                  container:
+                    image: "imag"e
+                  labels:
+                    app: test-label
+              EOF
+            check:
+              ($error != null): true
+              '(contains($stderr, ''The label key "app" is reserved and cannot be used as a label.''))': true
     - try:
         - delete:
             ref:


### PR DESCRIPTION
Add CEL validation that rejects 'app' as a key in spec.labels on Application and SKIPjob manifest. This is to prevent selector bug on sub resources where the 'app' label i set as the name of the Application or SKIPjob by skiperator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The label key "app" is now reserved and cannot be used on Applications and SKIPJobs. Attempts to create or update resources with this label key will be rejected with a clear validation error message indicating the label key is reserved and unavailable for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->