### PR TITLE
Add missing subResourceErrors

### DIFF
--- a/pkg/resourcegenerator/gcp/auth/configmap.go
+++ b/pkg/resourcegenerator/gcp/auth/configmap.go
@@ -64,6 +64,7 @@ func getConfigMap(r reconciliation.Reconciliation) error {
 	credentialsBytes, err := json.Marshal(credentials)
 	if err != nil {
 		ctxLog.Error(err, "could not marshall gcp identity config map")
+		err := &reconciliation.SubResourceError{Message: "Could not marshall gcp identity config map", WrapErr: err, Reason: reconciliation.InternalError}
 		return err
 	}
 

--- a/pkg/resourcegenerator/gcp/auth/configmap.go
+++ b/pkg/resourcegenerator/gcp/auth/configmap.go
@@ -63,7 +63,6 @@ func getConfigMap(r reconciliation.Reconciliation) error {
 
 	credentialsBytes, err := json.Marshal(credentials)
 	if err != nil {
-		ctxLog.Error(err, "could not marshall gcp identity configmap")
 		err := &reconciliation.SubResourceError{Message: "Could not marshall GCP identity ConfigMap", WrapErr: err, Reason: reconciliation.InternalError}
 		return err
 	}

--- a/pkg/resourcegenerator/gcp/auth/configmap.go
+++ b/pkg/resourcegenerator/gcp/auth/configmap.go
@@ -31,7 +31,7 @@ func Generate(r reconciliation.Reconciliation) error {
 	if r.GetType() == reconciliation.ApplicationType || r.GetType() == reconciliation.JobType {
 		return getConfigMap(r)
 	} else {
-		err := &reconciliation.SubResourceError{Message: "Unsupported type in GCP configmap", WrapErr: fmt.Errorf("unsupported type %s in gcp configmap", r.GetType()), Reason: reconciliation.UnsupportedTypeResource}
+		err := &reconciliation.SubResourceError{Message: "Unsupported type in GCP ConfigMap", WrapErr: fmt.Errorf("unsupported type %s in gcp configmap", r.GetType()), Reason: reconciliation.UnsupportedTypeResource}
 		return err
 	}
 }
@@ -63,8 +63,8 @@ func getConfigMap(r reconciliation.Reconciliation) error {
 
 	credentialsBytes, err := json.Marshal(credentials)
 	if err != nil {
-		ctxLog.Error(err, "could not marshall gcp identity config map")
-		err := &reconciliation.SubResourceError{Message: "Could not marshall gcp identity config map", WrapErr: err, Reason: reconciliation.InternalError}
+		ctxLog.Error(err, "could not marshall gcp identity configmap")
+		err := &reconciliation.SubResourceError{Message: "Could not marshall GCP identity ConfigMap", WrapErr: err, Reason: reconciliation.InternalError}
 		return err
 	}
 

--- a/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
+++ b/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
@@ -32,7 +32,7 @@ func getServiceEntries(r reconciliation.Reconciliation) error {
 	accessPolicy, err := setCloudSqlRule(accessPolicy, object)
 
 	if err != nil {
-		err := &reconciliation.SubResourceError{Message: "Could not set Cloud SQL Rules", WrapErr: err, Reason: reconciliation.InternalError}
+		err := &reconciliation.SubResourceError{Message: "Could not set Cloud SQL Rules for Service Entry", WrapErr: err, Reason: reconciliation.InternalError}
 		return err
 	}
 
@@ -58,7 +58,7 @@ func getServiceEntries(r reconciliation.Reconciliation) error {
 
 			ports, err := getPorts(rule.Ports, rule.Ip)
 			if err != nil {
-				err := &reconciliation.SubResourceError{Message: "Could not set port", WrapErr:err, Reason: reconciliation.InternalError }
+				err := &reconciliation.SubResourceError{Message: "Could not set port for Service Entry", WrapErr:err, Reason: reconciliation.InternalError }
 				return err
 			}
 

--- a/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
+++ b/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
@@ -58,7 +58,7 @@ func getServiceEntries(r reconciliation.Reconciliation) error {
 
 			ports, err := getPorts(rule.Ports, rule.Ip)
 			if err != nil {
-				err := &reconciliation.SubResourceError{Message: "Could not set port for Service Entry", WrapErr:err, Reason: reconciliation.InternalError }
+				err := &reconciliation.SubResourceError{Message: "Could not set port for Service Entry", WrapErr: err, Reason: reconciliation.InternalError}
 				return err
 			}
 

--- a/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
+++ b/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
@@ -32,6 +32,7 @@ func getServiceEntries(r reconciliation.Reconciliation) error {
 	accessPolicy, err := setCloudSqlRule(accessPolicy, object)
 
 	if err != nil {
+		err := &reconciliation.SubResourceError{Message: "Could not set Cloud SQL Rules", WrapErr: err, Reason: reconciliation.InternalError}
 		return err
 	}
 
@@ -57,6 +58,7 @@ func getServiceEntries(r reconciliation.Reconciliation) error {
 
 			ports, err := getPorts(rule.Ports, rule.Ip)
 			if err != nil {
+				err := &reconciliation.SubResourceError{Message: "Could not set port", WrapErr:err, Reason: reconciliation.InternalError }
 				return err
 			}
 


### PR DESCRIPTION
Adds subResourceErrors to the GCP auth ConfigMap and the Istio ServiceEntry, as they were missing. Also put reason as `InternalError` to not trigger reconciliation loops, as this errors are most likely triggered by manifest errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and standardization in GCP ConfigMap and Istio ServiceEntry resource generation, ensuring consistent error reporting and messaging across resource generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->