### PR TITLE
SKIP-1792: Fix flacky test by adding retry logic 

### DIFF
--- a/internal/controllers/common/reconciler.go
+++ b/internal/controllers/common/reconciler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/api/v1alpha1/podtypes"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/resourceutils"
@@ -19,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -37,7 +37,6 @@ type ReconcilerBase struct {
 	scheme           *runtime.Scheme
 	restConfig       *rest.Config
 	recorder         record.EventRecorder
-	Logger           logr.Logger
 }
 
 func NewReconcilerBase(
@@ -155,15 +154,22 @@ func (r *ReconcilerBase) SetSyncedState(ctx context.Context, skipObj v1alpha1.SK
 }
 
 func (r *ReconcilerBase) updateStatus(ctx context.Context, skipObj v1alpha1.SKIPObject) {
-	latestObj := skipObj.DeepCopyObject().(v1alpha1.SKIPObject)
 	key := client.ObjectKeyFromObject(skipObj)
-
-	if err := r.GetClient().Get(ctx, key, latestObj); err != nil {
-		r.Logger.Error(err, "Failed to get latest object version")
-	}
-	latestObj.SetStatus(*skipObj.GetStatus())
-	if err := r.GetClient().Status().Update(ctx, latestObj); err != nil {
-		r.Logger.Error(err, "Failed to update status")
+	err := retry.OnError(retry.DefaultBackoff, errors.IsConflict, func() error {
+		latestObj := skipObj.DeepCopyObject().(v1alpha1.SKIPObject)
+		if err := r.GetClient().Get(ctx, key, latestObj); err != nil {
+			ctrl.Log.Error(err, "Failed to get latest object version")
+			return err
+		}
+		latestObj.SetStatus(*skipObj.GetStatus())
+		if err := r.GetClient().Status().Update(ctx, latestObj); err != nil {
+			ctrl.Log.Error(err, "Failed to update status")
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		ctrl.Log.Error(err, "Failed to update status after retries")
 	}
 }
 


### PR DESCRIPTION
Adds retry logic for when a status update fails because of object conflict with kube API(error code 409), because of a race condition that occurs when Skiperator sets status as `Progressing` at the start of the reconcile loop and then when it find an error and try to change the status to `Error`. If this process happen to fast , Skiperator will try to update with the same `objectmetadata.resourceVersion` which leads to a 409 error from the kube API. Now if an 409 error is returned, it will lead to a retry

also changed logger for errors in `updateStatus` and removed the logger from reconcile struct as it doesn't seem to be initialized anywhere...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system resilience with automatic retry mechanism for status updates, now gracefully handling transient API conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->