### PR TITLE
Bump to Go 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 WORKDIR /build
 
 COPY go.mod go.sum ./

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS base
+FROM golang:1.26.3 AS base
 # Needed for ca-certs
 
 FROM scratch

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kartverket/skiperator
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/cert-manager/cert-manager v1.20.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.26.3 across build configurations, ensuring compatibility with the latest stable release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kartverket/skiperator/pull/866)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->