### PR TITLE
attest published images

### DIFF
--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -9,6 +9,8 @@ permissions:
   contents: write
   packages: write
   id-token: write
+  attestations: write
+  artifact-metadata: write
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -34,6 +36,9 @@ jobs:
 
       - run: git fetch --force --tags
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -56,10 +61,29 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve released image digest
+        id: image-digest
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          image="${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}"
+          digest="$(docker buildx imagetools inspect "${image}" --format '{{ printf "%s" .Manifest.Digest }}')"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Attest released image provenance
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.image-digest.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: true
+
   generate:
     name: CRD and ClusterRole
     needs: [ goreleaser ]

--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -30,35 +30,35 @@ jobs:
       DOCKER_BUILDKIT: 1
       DOCKER_EXPERIMENTAL: 1
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - run: git fetch --force --tags
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Log into GHCR registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Install Syft for SBOM Generation
         shell: bash
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Release with Goreleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -77,7 +77,7 @@ jobs:
 
       - name: Attest released image provenance
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.image-digest.outputs.digest }}
@@ -92,10 +92,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Golang environment
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -103,7 +103,7 @@ jobs:
         run: make generate
 
       - name: Upload CRD and ClusterRole
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |
@@ -128,13 +128,13 @@ jobs:
           identity: skiperator
 
       - name: Checkout apps repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: kartverket/skip-apps
           token: ${{ steps.octo-sts.outputs.token }}
 
       - name: Download CRD and RBAC
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: config/
@@ -166,4 +166,3 @@ jobs:
           EOF
 
           git push
-

--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -72,7 +72,10 @@ jobs:
         shell: bash
         run: |
           image="${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}"
-          digest="$(docker buildx imagetools inspect "${image}" --format '{{ printf "%s" .Manifest.Digest }}')"
+          digest="$(awk -v image="${image}" '$2 == image { print $1; found = 1 } END { exit !found }' dist/digests.txt)"
+          if [[ "${digest}" != sha256:* ]]; then
+            digest="sha256:${digest}"
+          fi
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Attest released image provenance

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,8 @@
 version: 2
 
 builds:
-  - env:
+  - id: skiperator
+    env:
       - CGO_ENABLED=0
     flags:
       - -trimpath
@@ -20,10 +21,9 @@ builds:
     tags:
       - osusergo
       - netgo
-    main: ./cmd/skiperator/
 
 archives:
-  - builds:
+  - ids:
       - skiperator
     files:
       - README.md
@@ -39,33 +39,30 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
-dockers:
-  - image_templates:
-      - "ghcr.io/kartverket/skiperator:{{ .Tag }}-linux-amd64"
-    use: buildx
+dockers_v2:
+  - images:
+      - "ghcr.io/kartverket/skiperator"
+    tags:
+      - "{{ .Tag }}"
     dockerfile: Dockerfile.goreleaser
-    build_flag_templates:
+    ids:
+      - skiperator
+    annotations:
+      "index:org.opencontainers.image.description": "{{ if not .IsSnapshot }}Skiperator is an operator intended to make the setup of applications simple from the users' point of view.{{ end }}"
+      "index:org.opencontainers.image.created": "{{.Date}}"
+      "index:org.opencontainers.image.name": "{{.ProjectName}}"
+      "index:org.opencontainers.image.revision": "{{.FullCommit}}"
+      "index:org.opencontainers.image.version": "{{.Version}}"
+      "index:org.opencontainers.image.source": "{{.GitURL}}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    sbom: false
+    flags:
       - "--pull"
-      - "--platform=linux/amd64"
-    goos: linux
-    goarch: amd64
-  - image_templates:
-      - "ghcr.io/kartverket/skiperator:{{ .Tag }}-linux-arm64"
-    use: buildx
-    dockerfile: Dockerfile.goreleaser
-    build_flag_templates:
-      - "--pull"
-      - "--platform=linux/arm64"
-    goos: linux
-    goarch: arm64
-
-docker_manifests:
-  - name_template: "ghcr.io/kartverket/skiperator:{{ .Tag }}"
-    image_templates:
-      - "ghcr.io/kartverket/skiperator:{{ .Tag }}-linux-arm64"
-      - "ghcr.io/kartverket/skiperator:{{ .Tag }}-linux-amd64"
 
 docker_signs:
   - artifacts: all
@@ -73,21 +70,27 @@ docker_signs:
     args:
       - "sign"
       - "--use-signing-config=false"
+      # sigstore/policy-controller v0.15.x verifies image signatures from the
+      # legacy cosign .sig tag; cosign v3 defaults to OCI referrer bundles.
+      - "--new-bundle-format=false"
+      - "--registry-referrers-mode=legacy"
       - "--oidc-issuer=https://token.actions.githubusercontent.com"
       - "${artifact}"
       - "--yes"
 
 signs:
-  - artifacts: all
+  - artifacts: checksum
     cmd: cosign
-    signature: "${artifact}.sig"
+    signature: "${artifact}.sigstore.json"
     args:
-    - "sign-blob"
-    - "--use-signing-config=false"
-    - "--oidc-issuer=https://token.actions.githubusercontent.com"
-    - "--output-signature=${signature}"
-    - "${artifact}"
-    - "--yes"
+      - "sign-blob"
+      - "--use-signing-config=false"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      # Cosign v3 stores blob verification material in a bundle; signing the
+      # checksum file covers the release assets without one Rekor entry each.
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
 
 sboms:
   - artifacts: archive

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,11 +1,12 @@
-FROM golang:1.26.3 AS base
+FROM --platform=$BUILDPLATFORM golang:1.26.3 AS base
 # Needed for ca-certs
 
 FROM scratch
+ARG TARGETPLATFORM
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 # Copy prebuilt binaries for that arch
-COPY skiperator /skiperator
+COPY $TARGETPLATFORM/skiperator /skiperator
 
 USER 65532:65532
 ENTRYPOINT ["/skiperator"]


### PR DESCRIPTION
Changes
- migrate Docker publishing the updated Goreleaser way
- publish GitHub/Sigstore provenance attestations for released images
- keep image signatures compatible with sigstore/policy-controller legacy verification

Verification can be done using the [`policy-tester`](https://github.com/sigstore/policy-controller#policy-testing) tool from cosign with the following policy:
```yaml
apiVersion: policy.sigstore.dev/v1alpha1
kind: ClusterImagePolicy
metadata:
  name: skiperator
  annotations:
    argocd.argoproj.io/sync-wave: "1"
spec:
  images:
    - glob: "ghcr.io/kartverket/skiperator:v*"
  authorities:
    - name: "github-ci"
      signatureFormat: bundle
      keyless:
        identities:
          - issuer: https://token.actions.githubusercontent.com
            subjectRegExp: https://github.com/kartverket/skiperator/.github/workflows/release-version.yaml@refs/tags/v.*
        url: https://fulcio.sigstore.dev
      attestations:
        - name: require-attestation
          predicateType: https://slsa.dev/provenance/v1
```

---

👦🏻  See my playground [here](https://github.com/evenh/some-app). Can also be tested with:
```
cosign tree ghcr.io/evenh/some-app:v0.8.0
📦 Supply Chain Security Related artifacts for an image: ghcr.io/evenh/some-app:v0.8.0
└── 🔐 Signatures for an image tag: ghcr.io/evenh/some-app:sha256-6e98cfd8667bf841652c3e200d69fd291ef78791421978aaf0dfaf4ced5baafe.sig
   └── 🍒 sha256:2b76aa22727b3d1c92ad02a0a8e011ccb96710ac7c1e449eca43572edfdfb0eb
└── 🔗 https://slsa.dev/provenance/v1 artifacts via OCI referrer: ghcr.io/evenh/some-app@sha256:4814e78ab29834d685e8db179e88372c20b798721cb6b5a44210eba5b524fe95
   └── 🍒 sha256:93edd2b7f56efd25cf787901a71df03b964758117cfafa0d2153caad4c84adb2
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added multi-architecture Docker image support (amd64, arm64) for correct platform binaries
  * Enabled image provenance attestations to improve supply chain security
  * Made release automation more deterministic by pinning CI actions and tightening workflow permissions
  * Improved artifact packaging and signing to use bundle-based signatures and artifact-focused signing
  * Exported image digests on tagged releases to ensure reproducible deployments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kartverket/skiperator/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->