### PR TITLE
Bump to Go 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3 AS builder
+FROM golang:1.26.4 AS builder
 WORKDIR /build
 
 COPY go.mod go.sum ./

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.3 AS base
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS base
 # Needed for ca-certs
 
 FROM scratch

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kartverket/skiperator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cert-manager/cert-manager v1.20.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain from version 1.26.3 to 1.26.4 across all build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->