### PR TITLE
extraContainer: fix network bugs

### DIFF
--- a/internal/controllers/common/reconciler.go
+++ b/internal/controllers/common/reconciler.go
@@ -16,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -192,7 +191,7 @@ func (r *ReconcilerBase) getTargetApplicationPorts(ctx context.Context, appName 
 
 	for _, port := range service.Spec.Ports {
 		servicePorts = append(servicePorts, networkingv1.NetworkPolicyPort{
-			Port: util.PointTo(intstr.FromInt32(port.Port)),
+			Port: new(port.TargetPort),
 		})
 	}
 	return servicePorts, nil

--- a/internal/controllers/routing.go
+++ b/internal/controllers/routing.go
@@ -86,7 +86,8 @@ func (r *RoutingReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		return reconcile.Result{Requeue: true}, err
 	}
 
-	if err := r.setDefaultSpec(ctx, routing); err != nil {
+	targetAppPorts, err := r.setDefaultSpec(ctx, routing)
+	if err != nil {
 		rLog.Error(err, "error when trying to set default spec")
 		r.SetErrorState(ctx, routing, err, "error when trying to set default spec", "DefaultSpecFailure")
 		return common.RequeueWithError(err)
@@ -98,7 +99,7 @@ func (r *RoutingReconciler) Reconcile(ctx context.Context, req reconcile.Request
 
 	istioEnabled := r.IsIstioEnabledForNamespace(ctx, routing.Namespace)
 
-	reconciliationRouting := reconciliation.NewRoutingReconciliation(ctx, routing, rLog, istioEnabled, r.GetRestConfig())
+	reconciliationRouting := reconciliation.NewRoutingReconciliation(ctx, routing, rLog, istioEnabled, r.GetRestConfig(), targetAppPorts)
 	resourceGeneration := []reconciliationFunc{
 		networkpolicy.Generate,
 		virtualservice.Generate,
@@ -162,25 +163,32 @@ func (r *RoutingReconciler) cleanUpWatchedResources(ctx context.Context, name ty
 	route.SetName(name.Name)
 	route.SetNamespace(name.Namespace)
 
-	reconciliation := reconciliation.NewRoutingReconciliation(ctx, route, log.NewLogger(), false, nil)
+	reconciliation := reconciliation.NewRoutingReconciliation(ctx, route, log.NewLogger(), false, nil, nil)
 
 	processor := resourceprocessor.NewResourceProcessor(r.GetClient(), resourceschemas.GetRoutingSchemas(r.GetScheme()), r.GetScheme())
 	return processor.Process(reconciliation)
 }
 
 // TODO Do this with application too for dynamic port allocation?
-func (r *RoutingReconciler) setDefaultSpec(ctx context.Context, routing *skiperatorv1alpha1.Routing) error {
+func (r *RoutingReconciler) setDefaultSpec(ctx context.Context, routing *skiperatorv1alpha1.Routing) (map[string]int32, error) {
+	targetAppPorts := make(map[string]int32)
 	for i := range routing.Spec.Routes {
 		route := &routing.Spec.Routes[i] // Get a pointer to the route in the slice
+		app, err := r.getTargetApplication(ctx, route.TargetApp, routing.Namespace)
+		if err != nil {
+			return nil, err
+		}
 		if route.Port == 0 {
-			app, err := r.getTargetApplication(ctx, route.TargetApp, routing.Namespace)
-			if err != nil {
-				return err
-			}
+			// Istio routes to the Service port.
 			route.Port = int32(app.Spec.Port)
 		}
+		targetAppPorts[route.TargetApp] = route.Port
+		if route.Port == int32(app.Spec.Port) {
+			// NetworkPolicy matches the pod-facing port after Service translation.
+			targetAppPorts[route.TargetApp] = int32(app.IngressTargetPort())
+		}
 	}
-	return nil
+	return targetAppPorts, nil
 }
 
 func (r *RoutingReconciler) setRoutingResourceDefaults(resources []client.Object, routing *skiperatorv1alpha1.Routing) error {

--- a/pkg/reconciliation/routing.go
+++ b/pkg/reconciliation/routing.go
@@ -10,10 +10,11 @@ import (
 
 type RoutingReconciliation struct {
 	baseReconciliation
+	targetAppPorts map[string]int32
 }
 
 func NewRoutingReconciliation(ctx context.Context, routing *skiperatorv1alpha1.Routing,
-	logger log.Logger, istioEnabled bool, restConfig *rest.Config) *RoutingReconciliation {
+	logger log.Logger, istioEnabled bool, restConfig *rest.Config, targetAppPorts map[string]int32) *RoutingReconciliation {
 	return &RoutingReconciliation{
 		baseReconciliation: baseReconciliation{
 			ctx:          ctx,
@@ -22,9 +23,20 @@ func NewRoutingReconciliation(ctx context.Context, routing *skiperatorv1alpha1.R
 			restConfig:   restConfig,
 			skipObject:   routing,
 		},
+		targetAppPorts: targetAppPorts,
 	}
 }
 
 func (r *RoutingReconciliation) GetType() ObjectType {
 	return RoutingType
+}
+
+func (r *RoutingReconciliation) GetTargetAppPort(targetApp string, fallbackPort int32) int32 {
+	if r.targetAppPorts == nil {
+		return fallbackPort
+	}
+	if port, ok := r.targetAppPorts[targetApp]; ok {
+		return port
+	}
+	return fallbackPort
 }

--- a/pkg/resourcegenerator/networkpolicy/dynamic/routing.go
+++ b/pkg/resourcegenerator/networkpolicy/dynamic/routing.go
@@ -29,6 +29,10 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 	}
 
 	for netpolName, route := range uniqueTargetApps {
+		targetPort := route.Port
+		if routingReconciliation, ok := r.(*reconciliation.RoutingReconciliation); ok {
+			targetPort = routingReconciliation.GetTargetAppPort(route.TargetApp, route.Port)
+		}
 		networkPolicy := networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: routing.Namespace,
@@ -56,7 +60,7 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 					},
 					Ports: []networkingv1.NetworkPolicyPort{
 						{
-							Port: util.PointTo(intstr.FromInt32(route.Port)),
+							Port: util.PointTo(intstr.FromInt32(targetPort)),
 						},
 					},
 				},

--- a/tests/application/extra-containers/application-outbound-to-auth-proxy-assert.yaml
+++ b/tests/application/extra-containers/application-outbound-to-auth-proxy-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: extra-containers-client
+spec:
+  podSelector:
+    matchLabels:
+      app: extra-containers-client
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ($namespace)
+          podSelector:
+            matchLabels:
+              app: extra-containers-proxy
+      ports:
+        - port: 8443

--- a/tests/application/extra-containers/application-outbound-to-auth-proxy.yaml
+++ b/tests/application/extra-containers/application-outbound-to-auth-proxy.yaml
@@ -1,0 +1,11 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: extra-containers-client
+spec:
+  image: image
+  port: 8080
+  accessPolicy:
+    outbound:
+      rules:
+        - application: extra-containers-proxy

--- a/tests/application/extra-containers/chainsaw-test.yaml
+++ b/tests/application/extra-containers/chainsaw-test.yaml
@@ -18,6 +18,11 @@ spec:
         - assert:
             file: application-auth-proxy-assert.yaml
     - try:
+        - create:
+            file: application-outbound-to-auth-proxy.yaml
+        - assert:
+            file: application-outbound-to-auth-proxy-assert.yaml
+    - try:
         # A reserved container-port name ("main") in additionalPorts must be
         # rejected specifically by the reserved-port CEL rule.
         - apply:

--- a/tests/routing/routes/application-extra-container.yaml
+++ b/tests/routing/routes/application-extra-container.yaml
@@ -1,0 +1,16 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: app-proxy
+spec:
+  image: image
+  port: 8080
+  extraContainers:
+    - name: auth-proxy
+      image: auth-proxy:1.0
+      type: init
+      ingressPort: 8443
+      additionalPorts:
+        - name: proxy
+          port: 8443
+          protocol: TCP

--- a/tests/routing/routes/chainsaw-test.yaml
+++ b/tests/routing/routes/chainsaw-test.yaml
@@ -17,6 +17,13 @@ spec:
             file: routing-assert.yaml
     - try:
         - apply:
+            file: application-extra-container.yaml
+        - apply:
+            file: routing-extra-container.yaml
+        - assert:
+            file: routing-extra-container-assert.yaml
+    - try:
+        - apply:
             file: patch-application-change-port.yaml
         - assert:
             file: patch-application-change-port-assert.yaml

--- a/tests/routing/routes/routing-extra-container-assert.yaml
+++ b/tests/routing/routes/routing-extra-container-assert.yaml
@@ -1,0 +1,52 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: app-proxy-paths-app-proxy-istio-ingress
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-gateways
+          podSelector:
+            matchLabels:
+              app: istio-ingress-external
+      ports:
+        - port: 8443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: app-proxy
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: app-proxy-paths-routing-ingress
+spec:
+  exportTo:
+    - .
+    - istio-system
+    - istio-gateways
+  gateways:
+    - app-proxy-paths-routing-ingress
+  hosts:
+    - proxy.example.com
+  http:
+    - match:
+        - port: 80
+      name: redirect-to-https
+      redirect:
+        redirectCode: 308
+        scheme: https
+    - match:
+        - port: 443
+          uri:
+            prefix: /proxy
+      name: app-proxy
+      route:
+        - destination:
+            host: app-proxy
+            port:
+              number: 8080

--- a/tests/routing/routes/routing-extra-container.yaml
+++ b/tests/routing/routes/routing-extra-container.yaml
@@ -1,0 +1,9 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: app-proxy-paths
+spec:
+  hostname: proxy.example.com
+  routes:
+    - pathPrefix: /proxy
+      targetApp: app-proxy


### PR DESCRIPTION
As reported by @nutgaard. Also fixed for `Routing`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Network policies now target the application’s actual ingress or pod-facing port, including routes involving extra containers.
  - Routing port resolution now correctly handles configured service target ports and falls back safely when no target port is available.

- **Tests**
  - Added coverage for outbound access to an authentication proxy.
  - Added routing coverage for applications using extra containers and custom proxy ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->