### PR TITLE
Handle accessPolicy.outbound.external that contains wildcard hosts

### DIFF
--- a/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
+++ b/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
@@ -54,11 +54,15 @@ func getServiceEntries(r reconciliation.Reconciliation) error {
 				serviceEntryName = fmt.Sprintf("%v-%v", strings.ToLower(objectKind), serviceEntryName)
 			}
 
-			resolution, addresses, endpoints := getIpData(rule.Ip)
-
 			ports, err := getPorts(rule.Ports, rule.Ip)
 			if err != nil {
 				err := &reconciliation.SubResourceError{Message: "Could not set port for Service Entry", WrapErr: err, Reason: reconciliation.InternalError}
+				return err
+			}
+
+			resolution, addresses, endpoints, err := getServiceEntryEndpointData(rule.Host, rule.Ip, ports)
+			if err != nil {
+				err := &reconciliation.SubResourceError{Message: "Could not set endpoint data for Service Entry", WrapErr: err, Reason: reconciliation.InternalError}
 				return err
 			}
 
@@ -116,12 +120,34 @@ func getPorts(externalPorts []podtypes.ExternalPort, ruleIP string) ([]*networki
 	return ports, nil
 }
 
-func getIpData(ip string) (networkingv1api.ServiceEntry_Resolution, []string, []*networkingv1api.WorkloadEntry) {
-	if ip == "" {
-		return networkingv1api.ServiceEntry_DNS, nil, nil
+func getServiceEntryEndpointData(host string, ip string, ports []*networkingv1api.ServicePort) (networkingv1api.ServiceEntry_Resolution, []string, []*networkingv1api.WorkloadEntry, error) {
+	if ip != "" {
+		return networkingv1api.ServiceEntry_STATIC, []string{ip}, []*networkingv1api.WorkloadEntry{{Address: ip}}, nil
 	}
 
-	return networkingv1api.ServiceEntry_STATIC, []string{ip}, []*networkingv1api.WorkloadEntry{{Address: ip}}
+	if isWildcardHost(host) {
+		if hasTCPPort(ports) {
+			return networkingv1api.ServiceEntry_NONE, nil, nil, errors.New("static IP must be set for TCP port with wildcard host")
+		}
+
+		return networkingv1api.ServiceEntry_NONE, nil, nil, nil
+	}
+
+	return networkingv1api.ServiceEntry_DNS, nil, nil, nil
+}
+
+func isWildcardHost(host string) bool {
+	return strings.HasPrefix(host, "*.")
+}
+
+func hasTCPPort(ports []*networkingv1api.ServicePort) bool {
+	for _, port := range ports {
+		if port.Protocol == "TCP" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func setCloudSqlRule(accessPolicy *podtypes.AccessPolicy, object skiperatorv1alpha1.SKIPObject) (*podtypes.AccessPolicy, error) {

--- a/pkg/resourcegenerator/istio/serviceentry/serviceentry_test.go
+++ b/pkg/resourcegenerator/istio/serviceentry/serviceentry_test.go
@@ -1,0 +1,99 @@
+package serviceentry
+
+import (
+	"testing"
+
+	"github.com/kartverket/skiperator/api/common/istiotypes"
+	"github.com/kartverket/skiperator/api/common/podtypes"
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	networkingv1api "istio.io/api/networking/v1"
+)
+
+func TestGetServiceEntryEndpointData(t *testing.T) {
+	tests := []struct {
+		name               string
+		host               string
+		ip                 string
+		ports              []*networkingv1api.ServicePort
+		expectedResolution networkingv1api.ServiceEntry_Resolution
+		expectedAddresses  []string
+		expectedEndpoint   string
+		expectedError      string
+	}{
+		{
+			name:               "plain host uses DNS resolution",
+			host:               "www.google.com",
+			expectedResolution: networkingv1api.ServiceEntry_DNS,
+		},
+		{
+			name:               "wildcard host uses NONE resolution",
+			host:               "*.google.com",
+			ports:              []*networkingv1api.ServicePort{{Protocol: "HTTPS"}},
+			expectedResolution: networkingv1api.ServiceEntry_NONE,
+		},
+		{
+			name:          "wildcard TCP without static IP is rejected",
+			host:          "*.google.com",
+			ports:         []*networkingv1api.ServicePort{{Protocol: "TCP"}},
+			expectedError: "static IP must be set for TCP port with wildcard host",
+		},
+		{
+			name:               "static IP uses STATIC resolution",
+			host:               "*.google.com",
+			ip:                 "1.2.3.4",
+			ports:              []*networkingv1api.ServicePort{{Protocol: "TCP"}},
+			expectedResolution: networkingv1api.ServiceEntry_STATIC,
+			expectedAddresses:  []string{"1.2.3.4"},
+			expectedEndpoint:   "1.2.3.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolution, addresses, endpoints, err := getServiceEntryEndpointData(tt.host, tt.ip, tt.ports)
+
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedResolution, resolution)
+			assert.Equal(t, tt.expectedAddresses, addresses)
+
+			if tt.expectedEndpoint == "" {
+				assert.Nil(t, endpoints)
+				return
+			}
+
+			if assert.Len(t, endpoints, 1) {
+				assert.Equal(t, tt.expectedEndpoint, endpoints[0].Address)
+			}
+		})
+	}
+}
+
+func TestGenerateRejectsWildcardTCPWithoutStaticIP(t *testing.T) {
+	r := testutil.GetTestMinimalAppReconciliation()
+	application := r.GetSKIPObject().(*skiperatorv1alpha1.Application)
+	application.Spec.IstioSettings = &istiotypes.IstioSettingsApplication{}
+	application.Spec.AccessPolicy = &podtypes.AccessPolicy{
+		Outbound: &podtypes.OutboundPolicy{
+			External: []podtypes.ExternalRule{
+				{
+					Host: "*.google.com",
+					Ports: []podtypes.ExternalPort{
+						{Name: "tcp", Port: 1234, Protocol: "TCP"},
+					},
+				},
+			},
+		},
+	}
+
+	err := Generate(r)
+
+	assert.ErrorContains(t, err, "static IP must be set for TCP port")
+	assert.Empty(t, r.GetResources())
+}


### PR DESCRIPTION
Fixes wildcard external ServiceEntries like `*.google.com`. Istio does not support `resolution: DNS` for wildcard hosts, so these entries need to use `resolution: NONE` unless they have an explicit static backend.

(extracted out of #924) 

## Changes

- Use `NONE` instead of `DNS` for wildcard ServiceEntry hosts.
- Keep explicit IP rules as `STATIC`.
- Reject wildcard raw TCP rules without a static IP backend.
- Add regression coverage for wildcard DNS, static IP, and unsupported wildcard TCP cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ServiceEntry generation for static IPs, wildcard hosts, and DNS-based hostnames.
  * Wildcard TCP configurations without a static IP are now rejected instead of generating invalid resources.
  * Static IP services now correctly include workload endpoints.

* **Tests**
  * Added coverage for DNS, wildcard, static-IP, and invalid wildcard TCP scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->