### PR TITLE
Fix domain check (strip wildcard)

### DIFF
--- a/internal/controllers/common/util.go
+++ b/internal/controllers/common/util.go
@@ -78,12 +78,16 @@ func IsExternalRulesValid(accessPolicy *podtypes.AccessPolicy) bool {
 			return true
 		}
 
-		if err := domain.Check(normalizedHost); err != nil {
+		if err := domain.Check(normalizeWildcardHost(normalizedHost)); err != nil {
 			return false
 		}
 	}
 
 	return true
+}
+
+func normalizeWildcardHost(host string) string {
+	return strings.TrimPrefix(host, "*.")
 }
 
 func GetInternalRulesCondition(obj common.SKIPObject, status metav1.ConditionStatus) metav1.Condition {

--- a/internal/controllers/common/util_test.go
+++ b/internal/controllers/common/util_test.go
@@ -108,6 +108,18 @@ func TestShouldNormalizeHosts(t *testing.T) {
 		assert.True(t, IsExternalRulesValid(cloudsqlHost))
 	})
 
+	t.Run("wildcard_domain", func(t *testing.T) {
+		wildcardDomain := externalPolicyTo(
+			podtypes.ExternalRule{
+				Host: "*.foo.com",
+				Ports: []podtypes.ExternalPort{
+					{Port: 443, Name: "https", Protocol: "HTTPS"},
+				},
+			},
+		)
+		assert.True(t, IsExternalRulesValid(wildcardDomain))
+	})
+
 	// Invalid cases
 	t.Run("duplicate_domain", func(t *testing.T) {
 		duplicateDomain := externalPolicyTo(
@@ -155,6 +167,18 @@ func TestShouldNormalizeHosts(t *testing.T) {
 			},
 		)
 		assert.False(t, IsExternalRulesValid(badHostname))
+	})
+
+	t.Run("bad_wildcard_hostname", func(t *testing.T) {
+		badWildcardHostname := externalPolicyTo(
+			podtypes.ExternalRule{
+				Host: "*foo.com",
+				Ports: []podtypes.ExternalPort{
+					{Port: 443, Name: "https", Protocol: "HTTPS"},
+				},
+			},
+		)
+		assert.False(t, IsExternalRulesValid(badWildcardHostname))
 	})
 
 	t.Run("protocol_in_host", func(t *testing.T) {


### PR DESCRIPTION
Small bugfix. Without this:
```
k get skipjob
NAME        STATUS   ACCESSPOLICIES
something   Synced   InvalidConfig    <-- It's valid but reporting invalid
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- Fix external hostname validation for wildcard domains.
- Strip the leading `*.` prefix before DNS validation.
- Prevent valid `SkipJob` resources from receiving an `InvalidConfig` access policy status.
- Add tests for valid and invalid wildcard hostnames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->