### PR TITLE
chore(mesh): extract pkg/mesh, fix hostname handling

### DIFF
--- a/api/common/hosts.go
+++ b/api/common/hosts.go
@@ -33,7 +33,7 @@ func NewHost(hostname string) (*Host, error) {
 	switch len(results) {
 	// No custom cert present
 	case 1:
-		h = Host{Hostname: results[0], CustomCertificateSecret: nil}
+		h = Host{Hostname: strings.ToLower(results[0]), CustomCertificateSecret: nil}
 	// Custom cert present
 	case 2:
 		secret := results[1]
@@ -41,7 +41,7 @@ func NewHost(hostname string) (*Host, error) {
 			return nil, fmt.Errorf("%s: not valid, custom certificate secret cannot be empty", hostname)
 		}
 
-		h = Host{Hostname: results[0], CustomCertificateSecret: &secret}
+		h = Host{Hostname: strings.ToLower(results[0]), CustomCertificateSecret: &secret}
 	// More than one '+' characters present
 	default:
 		return nil, fmt.Errorf("%s: not valid, contains multiple '%s' characters", hostname, hostnameSecretSeparator)

--- a/api/common/hosts_test.go
+++ b/api/common/hosts_test.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHostNormalizesHostname(t *testing.T) {
+	host, err := NewHost("API.example.COM+custom-tls")
+
+	require.NoError(t, err)
+	assert.Equal(t, "api.example.com", host.Hostname)
+	require.NotNil(t, host.CustomCertificateSecret)
+	assert.Equal(t, "custom-tls", *host.CustomCertificateSecret)
+}
+
+func TestHostCollectionDeduplicatesNormalizedHostnames(t *testing.T) {
+	hosts := NewCollection()
+
+	require.NoError(t, hosts.Add("API.example.com"))
+	require.NoError(t, hosts.Add("api.EXAMPLE.com"))
+
+	assert.Equal(t, 1, hosts.Count())
+	assert.Equal(t, []string{"api.example.com"}, hosts.Hostnames())
+}

--- a/internal/controllers/application.go
+++ b/internal/controllers/application.go
@@ -398,10 +398,10 @@ func (r *ApplicationReconciler) finalizeApplication(application *skiperatorv1alp
 }
 
 func (r *ApplicationReconciler) setApplicationResourcesDefaults(resources []client.Object, app *skiperatorv1alpha1.Application) error {
+	if err := r.SetSubresourceDefaults(resources, app); err != nil {
+		return err
+	}
 	for _, resource := range resources {
-		if err := r.SetSubresourceDefaults(resources, app); err != nil {
-			return err
-		}
 		resourceutils.SetApplicationLabels(resource, app)
 	}
 

--- a/internal/controllers/common/reconciler.go
+++ b/internal/controllers/common/reconciler.go
@@ -7,8 +7,8 @@ import (
 	"github.com/kartverket/skiperator/api/common"
 	"github.com/kartverket/skiperator/api/common/podtypes"
 	"github.com/kartverket/skiperator/pkg/log"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/resourceutils"
-	"github.com/kartverket/skiperator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -119,7 +119,7 @@ func (r *ReconcilerBase) IsIstioEnabledForNamespace(ctx context.Context, namespa
 		return false
 	}
 
-	v, exists := namespace.Labels[util.IstioRevisionLabel]
+	v, exists := namespace.Labels[mesh.RevisionLabel]
 
 	return exists && len(v) > 0
 }

--- a/internal/controllers/routing.go
+++ b/internal/controllers/routing.go
@@ -192,10 +192,10 @@ func (r *RoutingReconciler) setDefaultSpec(ctx context.Context, routing *skipera
 }
 
 func (r *RoutingReconciler) setRoutingResourceDefaults(resources []client.Object, routing *skiperatorv1alpha1.Routing) error {
+	if err := r.SetSubresourceDefaults(resources, routing); err != nil {
+		return err
+	}
 	for _, resource := range resources {
-		if err := r.SetSubresourceDefaults(resources, routing); err != nil {
-			return err
-		}
 		resourceutils.SetRoutingLabels(resource, routing)
 	}
 	return nil

--- a/internal/controllers/skipjob.go
+++ b/internal/controllers/skipjob.go
@@ -256,10 +256,10 @@ func (r *SKIPJobReconciler) teamNameForNamespace(ctx context.Context, skipJob *s
 	return "", fmt.Errorf("missing value for team label")
 }
 func (r *SKIPJobReconciler) setResourceDefaults(resources []client.Object, skipJob *skiperatorv1beta1.SKIPJob) error {
+	if err := r.SetSubresourceDefaults(resources, skipJob); err != nil {
+		return err
+	}
 	for _, resource := range resources {
-		if err := r.SetSubresourceDefaults(resources, skipJob); err != nil {
-			return err
-		}
 		resourceutils.SetSKIPJobLabels(resource, skipJob)
 	}
 	return nil

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -1,0 +1,50 @@
+// Package mesh describes how a namespace joins the Istio mesh, and holds the
+// labels, ports, and addresses that follow from that choice.
+package mesh
+
+import "k8s.io/apimachinery/pkg/util/intstr"
+
+const (
+	// RevisionLabel enables sidecar injection for a namespace.
+	RevisionLabel = "istio.io/rev"
+
+	// GatewayNamespace holds the shared ingress gateways, and SystemNamespace
+	// holds the control plane.
+	GatewayNamespace = "istio-gateways"
+	SystemNamespace  = "istio-system"
+
+	// MetricsPath is where the sidecar serves its Prometheus metrics.
+	MetricsPath = "/stats/prometheus"
+
+	// TraceProvider is the name of the trace provider set up in the istiod
+	// installation.
+	TraceProvider = "otel-tracing"
+)
+
+var (
+	// MetricsPortNumber and MetricsPortName address the sidecar metrics port.
+	MetricsPortNumber = intstr.FromInt32(15020)
+	MetricsPortName   = intstr.FromString("istio-metrics")
+
+	// DefaultMetricDropList holds the high-cardinality sidecar histograms that
+	// are dropped before ingestion.
+	DefaultMetricDropList = []string{
+		"istio_request_bytes_bucket",
+		"istio_response_bytes_bucket",
+		"istio_request_duration_milliseconds_bucket",
+	}
+)
+
+// IngressGatewayLabels selects the pods of the ingress gateway that serves a
+// hostname. Internal and external hostnames get separate gateway deployments.
+func IngressGatewayLabels(isInternal bool) map[string]string {
+	if isInternal {
+		return map[string]string{"app": "istio-ingress-internal"}
+	}
+	return map[string]string{"app": "istio-ingress-external"}
+}
+
+// GatewayNamespaceLabels selects the namespace the ingress gateways run in.
+func GatewayNamespaceLabels() map[string]string {
+	return map[string]string{"kubernetes.io/metadata.name": GatewayNamespace}
+}

--- a/pkg/resourcegenerator/istio/authorizationpolicy/common.go
+++ b/pkg/resourcegenerator/istio/authorizationpolicy/common.go
@@ -1,6 +1,7 @@
 package authorizationpolicy
 
 import (
+	"github.com/kartverket/skiperator/pkg/mesh"
 	v1 "istio.io/api/security/v1"
 )
 
@@ -12,7 +13,7 @@ func GetGeneralFromRule() []*v1.Rule_From {
 	return []*v1.Rule_From{
 		{
 			Source: &v1.Source{
-				Namespaces: []string{"istio-gateways"},
+				Namespaces: []string{mesh.GatewayNamespace},
 			},
 		},
 	}

--- a/pkg/resourcegenerator/istio/gateway/application.go
+++ b/pkg/resourcegenerator/istio/gateway/application.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/util"
 	networkingv1api "istio.io/api/networking/v1"
@@ -38,7 +39,7 @@ func generateForApplication(r reconciliation.Reconciliation) error {
 		name := fmt.Sprintf("%s-ingress-%x", application.Name, util.GenerateHashFromName(h.Hostname))
 		gateway := networkingv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: application.Namespace, Name: name}}
 
-		gateway.Spec.Selector = util.GetIstioGatewayLabelSelector(h.Hostname)
+		gateway.Spec.Selector = mesh.IngressGatewayLabels(util.IsInternal(h.Hostname))
 
 		gatewayServersToAdd := []*networkingv1api.Server{}
 

--- a/pkg/resourcegenerator/istio/gateway/routing.go
+++ b/pkg/resourcegenerator/istio/gateway/routing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/util"
 	networkingv1api "istio.io/api/networking/v1"
@@ -44,7 +45,7 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 		}
 	}
 
-	gateway.Spec.Selector = util.GetIstioGatewayLabelSelector(h.Hostname)
+	gateway.Spec.Selector = mesh.IngressGatewayLabels(util.IsInternal(h.Hostname))
 	gateway.Spec.Servers = []*networkingv1api.Server{
 		{
 			Hosts: []string{h.Hostname},

--- a/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
+++ b/pkg/resourcegenerator/istio/serviceentry/serviceentry.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kartverket/skiperator/api/common/podtypes"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/util"
 	networkingv1api "istio.io/api/networking/v1"
@@ -73,7 +74,7 @@ func getServiceEntries(r reconciliation.Reconciliation) error {
 				},
 				Spec: networkingv1api.ServiceEntry{
 					// Avoid leaking service entry to other namespaces
-					ExportTo:   []string{".", "istio-system", "istio-gateways"},
+					ExportTo:   []string{".", mesh.SystemNamespace, mesh.GatewayNamespace},
 					Hosts:      []string{rule.Host},
 					Resolution: resolution,
 					Addresses:  addresses,

--- a/pkg/resourcegenerator/istio/telemetry/telemetry.go
+++ b/pkg/resourcegenerator/istio/telemetry/telemetry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/util"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -33,7 +34,7 @@ func Generate(r reconciliation.Reconciliation) error {
 		telemetryTracing = append(telemetryTracing, &telemetryapiv1.Tracing{
 			Providers: []*telemetryapiv1.ProviderRef{
 				{
-					Name: util.IstioTraceProvider,
+					Name: mesh.TraceProvider,
 				},
 			},
 			RandomSamplingPercentage: util.PointTo(wrapperspb.DoubleValue{

--- a/pkg/resourcegenerator/networkpolicy/dynamic/common.go
+++ b/pkg/resourcegenerator/networkpolicy/dynamic/common.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kartverket/skiperator/api/common/podtypes"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/util"
 	v1 "k8s.io/api/core/v1"
@@ -203,7 +204,7 @@ func getIngressRules(accessPolicy *podtypes.AccessPolicy, ingresses []string, is
 			},
 			Ports: []networkingv1.NetworkPolicyPort{
 				{
-					Port: util.PointTo(util.IstioMetricsPortName),
+					Port: new(mesh.MetricsPortName),
 				},
 			},
 		}
@@ -288,10 +289,10 @@ func getGatewayIngressRule(isInternal bool, port int32) networkingv1.NetworkPoli
 		From: []networkingv1.NetworkPolicyPeer{
 			{
 				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"kubernetes.io/metadata.name": "istio-gateways"},
+					MatchLabels: mesh.GatewayNamespaceLabels(),
 				},
 				PodSelector: &metav1.LabelSelector{
-					MatchLabels: getIngressGatewayLabel(isInternal),
+					MatchLabels: mesh.IngressGatewayLabels(isInternal),
 				},
 			},
 		},
@@ -300,15 +301,6 @@ func getGatewayIngressRule(isInternal bool, port int32) networkingv1.NetworkPoli
 		ingressRule.Ports = []networkingv1.NetworkPolicyPort{{Port: util.PointTo(intstr.FromInt32(port))}}
 	}
 	return ingressRule
-}
-
-// TODO Should be in constants or something
-func getIngressGatewayLabel(isInternal bool) map[string]string {
-	if isInternal {
-		return map[string]string{"app": "istio-ingress-internal"}
-	} else {
-		return map[string]string{"app": "istio-ingress-external"}
-	}
 }
 
 var sortNetPolPorts = func(a networkingv1.NetworkPolicyPort, b networkingv1.NetworkPolicyPort) int {

--- a/pkg/resourcegenerator/networkpolicy/dynamic/routing.go
+++ b/pkg/resourcegenerator/networkpolicy/dynamic/routing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/util"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -51,10 +52,10 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 					From: []networkingv1.NetworkPolicyPeer{
 						{
 							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: util.GetIstioGatewaySelector(),
+								MatchLabels: mesh.GatewayNamespaceLabels(),
 							},
 							PodSelector: &metav1.LabelSelector{
-								MatchLabels: util.GetIstioGatewayLabelSelector(routing.Spec.Hostname),
+								MatchLabels: mesh.IngressGatewayLabels(util.IsInternal(routing.Spec.Hostname)),
 							},
 						},
 					},

--- a/pkg/resourcegenerator/pod/pod.go
+++ b/pkg/resourcegenerator/pod/pod.go
@@ -7,6 +7,7 @@ import (
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	skiperatorv1beta1 "github.com/kartverket/skiperator/api/v1beta1"
 	"github.com/kartverket/skiperator/internal/config"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/volume"
 	"github.com/kartverket/skiperator/pkg/util"
 	"github.com/kartverket/skiperator/pkg/util/array"
@@ -353,8 +354,8 @@ func getContainerPorts(application *skiperatorv1alpha1.Application, opts PodOpts
 	// Expose Prometheus telemetry to Service, so it can be picked up from ServiceMonitor
 	if opts.IstioEnabled {
 		containerPorts = append(containerPorts, corev1.ContainerPort{
-			Name:          util.IstioMetricsPortName.StrVal,
-			ContainerPort: util.IstioMetricsPortNumber.IntVal,
+			Name:          mesh.MetricsPortName.StrVal,
+			ContainerPort: mesh.MetricsPortNumber.IntVal,
 			Protocol:      corev1.ProtocolTCP,
 		})
 	}

--- a/pkg/resourcegenerator/prometheus/pod_monitor.go
+++ b/pkg/resourcegenerator/prometheus/pod_monitor.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	skiperatorv1beta1 "github.com/kartverket/skiperator/api/v1beta1"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/util"
 	pov1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -44,8 +45,8 @@ func generateForSkipJob(r reconciliation.Reconciliation) error {
 		},
 		PodMetricsEndpoints: []pov1.PodMetricsEndpoint{
 			{
-				Path:       util.IstioMetricsPath,
-				TargetPort: &util.IstioMetricsPortName,
+				Path:       mesh.MetricsPath,
+				TargetPort: new(mesh.MetricsPortName),
 				Interval:   getScrapeInterval(skipJob.Spec.Prometheus),
 			},
 		},
@@ -54,7 +55,7 @@ func generateForSkipJob(r reconciliation.Reconciliation) error {
 		podMonitor.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs = []pov1.RelabelConfig{
 			{
 				Action:       "drop",
-				Regex:        strings.Join(util.DefaultMetricDropList, "|"),
+				Regex:        strings.Join(mesh.DefaultMetricDropList, "|"),
 				SourceLabels: []pov1.LabelName{"__name__"},
 			},
 		}

--- a/pkg/resourcegenerator/prometheus/service_monitor.go
+++ b/pkg/resourcegenerator/prometheus/service_monitor.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/util"
 	pov1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -47,13 +48,13 @@ func generateForApplication(r reconciliation.Reconciliation) error {
 		},
 		Endpoints: []pov1.Endpoint{
 			{
-				Path:       util.IstioMetricsPath,
-				TargetPort: &util.IstioMetricsPortName,
+				Path:       mesh.MetricsPath,
+				TargetPort: new(mesh.MetricsPortName),
 				Interval:   getScrapeInterval(application.Spec.Prometheus),
 				MetricRelabelConfigs: []pov1.RelabelConfig{
 					{
 						Action:       "drop",
-						Regex:        strings.Join(util.DefaultMetricDropList, "|"),
+						Regex:        strings.Join(mesh.DefaultMetricDropList, "|"),
 						SourceLabels: []pov1.LabelName{"__name__"},
 					},
 				},

--- a/pkg/resourcegenerator/service/service.go
+++ b/pkg/resourcegenerator/service/service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kartverket/skiperator/api/common/podtypes"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/resourceutils"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/statefulset"
@@ -18,10 +19,10 @@ import (
 const defaultPortName = "http"
 
 var defaultPrometheusPort = corev1.ServicePort{
-	Name:       util.IstioMetricsPortName.StrVal,
+	Name:       mesh.MetricsPortName.StrVal,
 	Protocol:   corev1.ProtocolTCP,
-	Port:       util.IstioMetricsPortNumber.IntVal,
-	TargetPort: util.IstioMetricsPortNumber,
+	Port:       mesh.MetricsPortNumber.IntVal,
+	TargetPort: mesh.MetricsPortNumber,
 }
 
 func Generate(r reconciliation.Reconciliation) error {

--- a/pkg/resourceprocessor/crud.go
+++ b/pkg/resourceprocessor/crud.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -106,7 +107,7 @@ func (r *ResourceProcessor) listResourcesByLabels(ctx context.Context, namespace
 }
 
 func (r *ResourceProcessor) getCertificates(ctx context.Context, labels map[string]string, objList *[]client.Object) error {
-	return r.listResourcesByLabels(ctx, "istio-gateways", labels, objList)
+	return r.listResourcesByLabels(ctx, mesh.GatewayNamespace, labels, objList)
 }
 
 // TODO: Should we compare annotations?

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,27 +1,8 @@
 package util
 
-import (
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-)
+import corev1 "k8s.io/api/core/v1"
 
 const SkiperatorUser = int64(150)
-
-var (
-	IstioMetricsPortNumber = intstr.FromInt32(15020)
-	IstioMetricsPortName   = intstr.FromString("istio-metrics")
-	IstioMetricsPath       = "/stats/prometheus"
-	// IstioTraceProvider Name of the trace provider set up in the istiod installation
-	IstioTraceProvider = "otel-tracing"
-
-	IstioRevisionLabel = "istio.io/rev"
-
-	DefaultMetricDropList = []string{
-		"istio_request_bytes_bucket",
-		"istio_response_bytes_bucket",
-		"istio_request_duration_milliseconds_bucket",
-	}
-)
 
 // A security context for use in pod containers created by Skiperator
 // follow least privilege best practices for the whole Container Security Context

--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -25,7 +25,10 @@ import (
 
 //TODO Clean up this file, move functions to more appropriate files
 
-var internalPattern = regexp.MustCompile(`[^.]\.skip\.statkart\.no|[^.]\.kartverket-intern.cloud`)
+// Anchored at the end so an internal suffix only matches the real domain, not
+// a lookalike like "app.skip.statkart.no.attacker.com". The dot before each TLD
+// is escaped so it matches a literal dot rather than any character.
+var internalPattern = regexp.MustCompile(`(?i)[^.]\.(?:skip\.statkart\.no|kartverket-intern\.cloud)$`)
 
 func IsInternal(hostname string) bool {
 	return internalPattern.MatchString(hostname)

--- a/pkg/util/helperfunctions.go
+++ b/pkg/util/helperfunctions.go
@@ -31,14 +31,6 @@ func IsInternal(hostname string) bool {
 	return internalPattern.MatchString(hostname)
 }
 
-func GetIstioGatewayLabelSelector(hostname string) map[string]string {
-	if IsInternal(hostname) {
-		return map[string]string{"app": "istio-ingress-internal"}
-	}
-	return map[string]string{"app": "istio-ingress-external"}
-
-}
-
 func GetHashForStructs(obj []interface{}) string {
 	hash, err := hashstructure.Hash(obj, hashstructure.FormatV2, nil)
 	if err != nil {
@@ -131,10 +123,6 @@ func PointToInt64(n int64) *int64 {
 	return &n
 }
 
-func GetIstioGatewaySelector() map[string]string {
-	return map[string]string{"kubernetes.io/metadata.name": "istio-gateways"}
-}
-
 func GetPodAppSelector(applicationName string) map[string]string {
 	return map[string]string{"app": applicationName}
 }
@@ -158,10 +146,6 @@ func HasUpperCaseLetter(word string) bool {
 
 func ResourceNameWithKindPostfix(resourceName string, kind string) string {
 	return strings.ToLower(fmt.Sprintf("%v-%v", resourceName, kind))
-}
-
-func GetGatewaySecretName(namespace string, name string) string {
-	return fmt.Sprintf("%s-%s-ingress", namespace, name)
 }
 
 func GetSecretName(prefix string, name string) (string, error) {

--- a/pkg/util/helperfunctions_test.go
+++ b/pkg/util/helperfunctions_test.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsInternalIsCaseInsensitive(t *testing.T) {
+	assert.True(t, IsInternal("API.SKIP.STATKART.NO"))
+	assert.True(t, IsInternal("api.KARTVERKET-INTERN.CLOUD"))
+}
+
+func TestIsInternalMatchesOnlyTheRealDomainSuffix(t *testing.T) {
+	assert.True(t, IsInternal("app.skip.statkart.no"))
+	assert.True(t, IsInternal("foo.bar.kartverket-intern.cloud"))
+
+	// Lookalike hosts that merely contain the internal domain must not match.
+	assert.False(t, IsInternal("app.skip.statkart.no.attacker.com"))
+	assert.False(t, IsInternal("skip.statkart.no.evil.example"))
+	// Unescaped dot previously let any character match before "cloud".
+	assert.False(t, IsInternal("api.kartverket-internXcloud"))
+}

--- a/tests/application/ingress/ingress-validation-assert.yaml
+++ b/tests/application/ingress/ingress-validation-assert.yaml
@@ -26,14 +26,62 @@ source:
 involvedObject:
   apiVersion: skiperator.kartverket.no/v1alpha1
   kind: Application
-  name: ingresses-capital
----
-apiVersion: v1
-kind: Event
-reason: InvalidApplication
-source:
-  component: application-controller
-involvedObject:
-  apiVersion: skiperator.kartverket.no/v1alpha1
-  kind: Application
   name: ingresses-no-domain
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  namespace: istio-gateways
+  name: ingress-ingresses-capital-ingress-34888c0b0c2a4a2c
+spec:
+  issuerRef:
+    kind: ClusterIssuer
+    name: cluster-issuer
+  secretName: ingress-ingresses-capital-ingress-34888c0b0c2a4a2c
+  dnsNames:
+    - test.com
+---
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: ingresses-capital-ingress-34888c0b0c2a4a2c
+spec:
+  servers:
+    - hosts:
+        - test.com
+      port:
+        name: http
+        number: 80
+        protocol: HTTP
+    - hosts:
+        - test.com
+      port:
+        name: https
+        number: 443
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        credentialName: ingress-ingresses-capital-ingress-34888c0b0c2a4a2c
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: ingresses-capital-ingress
+spec:
+  exportTo:
+    - .
+    - istio-system
+    - istio-gateways
+  gateways:
+    - ingresses-capital-ingress-34888c0b0c2a4a2c
+  hosts:
+    - test.com
+  http:
+    - match:
+        - port: 80
+      redirect:
+        redirectCode: 308
+        scheme: https
+    - route:
+        - destination:
+            host: ingresses-capital


### PR DESCRIPTION
Layer 1 of 9. Part of the stack that replaces #884.

This layer changes no behaviour that Gateway API depends on. It is the groundwork
the later layers build on, plus two fixes found while doing it.

## What this does

- Moves Istio constants and gateway selectors out of `pkg/util` into a new
  `pkg/mesh` package. `pkg/util` held Istio port numbers and label keys next to
  unrelated helpers, so nothing named the concept they belong to.
- Anchors the internal-hostname pattern. The old pattern matched anywhere in the
  string, so `app.skip.statkart.no.attacker.com` was treated as internal and
  routed to the internal ingress gateway. Matching is now anchored at the end,
  the dots are escaped, and it is case insensitive.
- Lower-cases hostnames when parsing them. Two spellings of one hostname counted
  as two hosts, and each produced its own resources under a different name hash.
- Hoists `SetSubresourceDefaults` out of three resource loops. It ran one full
  pass per resource, so it did O(n^2) work for no gain.

## Review notes

The mesh move is mechanical. The two fixes change behaviour:

- `IsInternal` now rejects lookalike hostnames. Check that no legitimate SKIP
  hostname relies on the old unanchored match.
- Lower-casing makes an Application with a capitalised ingress valid where it was
  rejected before. The `tests/application/ingress` suite asserts the generated
  resources instead of the rejection event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- Added the `pkg/mesh` package for Istio constants and gateway selectors.
- Normalized hostnames to lowercase during parsing.
- Made internal hostname matching case insensitive and anchored.
- Reduced repeated subresource default processing during reconciliation.
- Updated ingress tests for capitalized hostnames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->