### PR TITLE
feat(gatewayapi): fail fast when Gateway API is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ TOOLS_DIR                          := $(PWD)/.tools
 KUBECTL                            := $(PWD)/bin/kubectl
 KIND                               := $(TOOLS_DIR)/kind
 CERT_MANAGER_VERSION               := $(call extract-version,github.com/cert-manager/cert-manager)
+GWAPI_VERSION                      := $(call extract-version,sigs.k8s.io/gateway-api)
 ISTIO_VERSION                      := $(call extract-version,istio.io/client-go)
 PROMETHEUS_VERSION                 := $(call extract-version,github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring)
 
@@ -106,6 +107,9 @@ ISTIO_IMAGES = docker.io/istio/proxyv2:$(ISTIO_VERSION) docker.io/istio/pilot:$(
 
 .PHONY: install-istio
 install-istio: ensure-kubectl
+	@echo "Installing Gateway API crds"
+	@kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v$(GWAPI_VERSION)/standard-install.yaml --context $(SKIPERATOR_CONTEXT)
+
 	@echo "Creating istio-gateways namespace..."
 	@kubectl create namespace istio-gateways --context $(SKIPERATOR_CONTEXT) || true
 
@@ -124,6 +128,8 @@ install-istio: ensure-kubectl
 	@curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$(ISTIO_VERSION) TARGET_ARCH=$(ARCH) sh -
 	@echo "Installing Istio on Kubernetes cluster..."
 	@./istio-$(ISTIO_VERSION)/bin/istioctl install -y --context $(SKIPERATOR_CONTEXT)
+	@echo "Creating tag asm-stable..."
+	@./istio-$(ISTIO_VERSION)/bin/istioctl tag set asm-stable --revision=default --overwrite --context $(SKIPERATOR_CONTEXT)
 	@echo "Istio installation complete."
 
 .PHONY: install-cert-manager

--- a/cmd/skiperator/main.go
+++ b/cmd/skiperator/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kartverket/skiperator/pkg/metrics/usage"
 	"github.com/kartverket/skiperator/pkg/resourceschemas"
 	"go.uber.org/zap/zapcore"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
@@ -116,6 +117,7 @@ func main() {
 	setupLog.Info(fmt.Sprintf("Starting skiperator using kube-apiserver at %s", kubeconfig.Host))
 
 	detectK8sVersion(kubeconfig)
+	requireGatewayAPI(ctx, kubeconfig)
 
 	pprofBindAddr := ""
 	if activeConfig.EnableProfiling {
@@ -315,4 +317,25 @@ func detectK8sVersion(kubeconfig *rest.Config) {
 	}
 	k8sfeatures.NewVersionInfo(ver)
 	setupLog.Info("detected server version", "version", ver)
+}
+
+func requireGatewayAPI(ctx context.Context, kubeconfig *rest.Config) {
+	xc, err := apiextensionsclient.NewForConfig(kubeconfig)
+	if err != nil {
+		setupLog.Error(err, "could not create API extensions client")
+		os.Exit(1)
+	}
+
+	err = k8sfeatures.CheckCRDsPresent(
+		ctx,
+		xc,
+		k8sfeatures.CRDRequirement{Name: "gateways.gateway.networking.k8s.io", Versions: []string{"v1"}},
+		k8sfeatures.CRDRequirement{Name: "httproutes.gateway.networking.k8s.io", Versions: []string{"v1"}},
+		k8sfeatures.CRDRequirement{Name: "listenersets.gateway.networking.k8s.io", Versions: []string{"v1"}},
+	)
+	if err != nil {
+		setupLog.Error(err, "Gateway API >= 1.5.0 is required")
+		os.Exit(1)
+	}
+	setupLog.Info("detected Gateway API v1 with ListenerSet support")
 }

--- a/pkg/k8sfeatures/crd.go
+++ b/pkg/k8sfeatures/crd.go
@@ -1,0 +1,72 @@
+package k8sfeatures
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type CRDRequirement struct {
+	Name     string
+	Versions []string
+}
+
+func IsCRDPresent(ctx context.Context, client apiextensionsclient.Interface, name string, versions ...string) bool {
+	return CheckCRDPresent(ctx, client, name, versions...) == nil
+}
+
+func CheckCRDPresent(ctx context.Context, client apiextensionsclient.Interface, name string, versions ...string) error {
+	if client == nil {
+		return fmt.Errorf("could not create API extensions client")
+	}
+
+	crd, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(
+		ctx,
+		name,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("missing CRD %q: %w", name, err)
+	}
+
+	missingVersions := make([]string, 0)
+	for _, requiredVersion := range versions {
+		found := false
+		for _, version := range crd.Spec.Versions {
+			if version.Name == requiredVersion && version.Served {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missingVersions = append(missingVersions, requiredVersion)
+		}
+	}
+	if len(missingVersions) > 0 {
+		return fmt.Errorf(
+			"CRD %q is missing served versions: %s",
+			name,
+			strings.Join(missingVersions, ", "),
+		)
+	}
+
+	return nil
+}
+
+func CheckCRDsPresent(ctx context.Context, client apiextensionsclient.Interface, requirements ...CRDRequirement) error {
+	for _, requirement := range requirements {
+		if err := CheckCRDPresent(
+			ctx,
+			client,
+			requirement.Name,
+			requirement.Versions...,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/k8sfeatures/crd_test.go
+++ b/pkg/k8sfeatures/crd_test.go
@@ -1,0 +1,52 @@
+package k8sfeatures
+
+import (
+	"context"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsCRDPresent(t *testing.T) {
+	client := apiextensionsfake.NewSimpleClientset(crd("widgets.example.com", "v1"))
+
+	if !IsCRDPresent(context.Background(), client, "widgets.example.com", "v1") {
+		t.Fatal("expected CRD with served version to be present")
+	}
+}
+
+func TestCheckCRDPresentMissingCRD(t *testing.T) {
+	client := apiextensionsfake.NewSimpleClientset()
+
+	if err := CheckCRDPresent(context.Background(), client, "widgets.example.com"); err == nil {
+		t.Fatal("expected missing CRD to return an error")
+	}
+}
+
+func TestCheckCRDPresentMissingVersion(t *testing.T) {
+	client := apiextensionsfake.NewSimpleClientset(crd("widgets.example.com", "v1alpha1"))
+
+	if err := CheckCRDPresent(context.Background(), client, "widgets.example.com", "v1"); err == nil {
+		t.Fatal("expected missing served version to return an error")
+	}
+}
+
+func crd(name string, versions ...string) *apiextensionsv1.CustomResourceDefinition {
+	crdVersions := make([]apiextensionsv1.CustomResourceDefinitionVersion, 0, len(versions))
+	for _, version := range versions {
+		crdVersions = append(crdVersions, apiextensionsv1.CustomResourceDefinitionVersion{
+			Name:    version,
+			Served:  true,
+			Storage: version == versions[0],
+		})
+	}
+
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Versions: crdVersions,
+		},
+	}
+}

--- a/tests/cluster-config/cluster-issuer.yaml
+++ b/tests/cluster-config/cluster-issuer.yaml
@@ -1,0 +1,28 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-bootstrap
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: local-test-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: SKIP E2E Test CA
+  secretName: local-test-ca
+  issuerRef:
+    name: selfsigned-bootstrap
+    kind: ClusterIssuer
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cluster-issuer
+spec:
+  # For real environments ACME issuer should be used, but for testing purposes self-signed is sufficient
+  ca:
+    secretName: local-test-ca

--- a/tests/cluster-config/gateways.yaml
+++ b/tests/cluster-config/gateways.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gw-options
+  namespace: istio-gateways
+data:
+  service: |
+    spec:
+      type: ClusterIP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: istio-external
+  namespace: istio-gateways
+spec:
+  gatewayClassName: istio
+  infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: gw-options
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+    - name: placeholder-http
+      hostname: placeholder.external.invalid
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: placeholder-https
+      hostname: placeholder.external.invalid
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: placeholder-tls
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: istio-internal
+  namespace: istio-gateways
+spec:
+  gatewayClassName: istio
+  infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: gw-options
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+    - name: placeholder-http
+      hostname: placeholder.internal.invalid
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: placeholder-https
+      hostname: placeholder.internal.invalid
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: placeholder-tls
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+kind: Certificate
+apiVersion: cert-manager.io/v1
+metadata:
+  name: placeholder-tls
+  namespace: istio-gateways
+spec:
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: cluster-issuer
+  secretName: placeholder-tls
+  dnsNames:
+    - placeholder.internal.invalid


### PR DESCRIPTION
Layer 2 of 9. Part of the stack that replaces #884. Builds on #933.

SKIP-1313

## What this does

Skiperator now checks at startup that the cluster has the Gateway API CRDs, and
exits with one clear error if it does not.

Without the check, a missing CRD surfaces later as a per-object failure on the
first Application that asks for Standard routing. That reads as a problem with
the Application, not with the cluster.

`ListenerSet` reached `v1` in Gateway API 1.5.0, so the check requires a served
`v1` for `gateways`, `httproutes` and `listenersets`.

## Also here

`make setup-local` produced a cluster the test suite could not fully run against:

- Gateway API CRDs were never installed.
- The namespaces in `tests/application/access-policy` and
  `tests/skipjob/access-policy-job` use `istio.io/rev: asm-stable`, a revision tag
  the local istiod never had, so sidecar injection never happened there.

The Gateway API version follows `go.mod`, the same way the Istio and Prometheus
versions already do. The shared Gateway and ClusterIssuer that later layers
attach to are applied from `tests/cluster-config`.

