### PR TITLE
feat(api): add Ready condition and spec.routingProvider

### DIFF
--- a/api-docs.md
+++ b/api-docs.md
@@ -326,6 +326,17 @@ This allows product teams to avoid the need to set up networking on the cluster,
         <td>false</td>
       </tr>
       <tr>
+        <td><b>routingProvider</b></td>
+        <td>enum</td>
+        <td>
+          RoutingProvider controls which routing API Skiperator uses for ingresses.<br/>Legacy uses Istio Gateway and VirtualService. Standard uses Kubernetes Gateway API.<br/>
+          <br/>
+            <i>Enum</i>: Legacy, Standard<br/>
+            <i>Default</i>: `Legacy`<br/>
+        </td>
+        <td>false</td>
+      </tr>
+      <tr>
         <td><b><a href="#applicationspecstartup">startup</a></b></td>
         <td>object</td>
         <td>
@@ -4356,6 +4367,17 @@ Status
           <br/>
           <br/>
             <i>Default</i>: `true`<br/>
+        </td>
+        <td>false</td>
+      </tr>
+      <tr>
+        <td><b>routingProvider</b></td>
+        <td>enum</td>
+        <td>
+          RoutingProvider controls which routing API Skiperator uses.<br/>Legacy uses Istio Gateway and VirtualService. Standard uses Kubernetes Gateway API.<br/>
+          <br/>
+            <i>Enum</i>: Legacy, Standard<br/>
+            <i>Default</i>: `Legacy`<br/>
         </td>
         <td>false</td>
       </tr>

--- a/api/common/status_types.go
+++ b/api/common/status_types.go
@@ -1,6 +1,9 @@
 package common
 
 import (
+	"sort"
+
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,7 +40,47 @@ const (
 	PENDING       StatusNames = "Pending"
 	READY         StatusNames = "Ready"
 	INVALIDCONFIG StatusNames = "InvalidConfig"
+
+	ReadyConditionType                = "Ready"
+	StandardRoutingReadyConditionType = "StandardRoutingReady"
+	LegacyRoutingActiveConditionType  = "LegacyRoutingActive"
 )
+
+// conditionOrder is the canonical order status conditions are persisted in.
+// meta.SetStatusCondition appends new conditions in first-seen order, which
+// makes the stored order depend on reconcile history (e.g. routing conditions
+// primed before access-policy conditions during a pending migration). Sorting
+// by this map before persisting keeps status output deterministic.
+// String literals (not the SKIPJob constants) because api/common is imported by
+// the SKIPJob types, so it cannot import them back.
+var conditionOrder = map[string]int{
+	ReadyConditionType:                0,
+	"Failed":                          1,
+	"Running":                         2,
+	"Finished":                        3,
+	"InternalRulesValid":              4,
+	"ExternalRulesValid":              5,
+	LegacyRoutingActiveConditionType:  6,
+	StandardRoutingReadyConditionType: 7,
+}
+
+// SortConditions orders Conditions canonically (see conditionOrder), so the
+// persisted status does not depend on the order conditions were first added
+// across reconciles. Unknown condition types are kept, in stable order, after
+// the known ones.
+func (s *SkiperatorStatus) SortConditions() {
+	sort.SliceStable(s.Conditions, func(i, j int) bool {
+		oi, oki := conditionOrder[s.Conditions[i].Type]
+		oj, okj := conditionOrder[s.Conditions[j].Type]
+		if oki != okj {
+			return oki
+		}
+		if !oki {
+			return false
+		}
+		return oi < oj
+	})
+}
 
 func (s *SkiperatorStatus) SetSummaryPending() {
 	s.Summary.Status = PENDING
@@ -58,14 +101,22 @@ func (s *SkiperatorStatus) SetSummarySynced() {
 }
 
 func (s *SkiperatorStatus) SetSummaryProgressing() {
+	s.SetSummaryProgressingMessage("Resource is progressing")
+	s.SubResources = make(map[string]Status)
+	s.AccessPolicies = PENDING
+}
+
+// SetSummaryProgressingMessage marks the summary as progressing with a custom
+// message, without resetting subresource state. Use after subresources are
+// reconciled but an asynchronous dependency (e.g. standard routing readiness)
+// is still pending.
+func (s *SkiperatorStatus) SetSummaryProgressingMessage(message string) {
 	s.Summary.Status = PROGRESSING
-	s.Summary.Message = "Resource is progressing"
+	s.Summary.Message = message
 	s.Summary.TimeStamp = metav1.Now().String()
 	if s.Conditions == nil {
 		s.Conditions = make([]metav1.Condition, 0)
 	}
-	s.SubResources = make(map[string]Status)
-	s.AccessPolicies = PENDING
 }
 
 func (s *SkiperatorStatus) SetSummaryError(errorMsg string) {
@@ -75,6 +126,29 @@ func (s *SkiperatorStatus) SetSummaryError(errorMsg string) {
 	if s.Conditions == nil {
 		s.Conditions = make([]metav1.Condition, 0)
 	}
+}
+
+func (s *SkiperatorStatus) setCondition(conditionType string, status metav1.ConditionStatus, observedGeneration int64, reason string, message string) {
+	meta.SetStatusCondition(&s.Conditions, metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		ObservedGeneration: observedGeneration,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+func (s *SkiperatorStatus) SetReadyCondition(status metav1.ConditionStatus, observedGeneration int64, reason string, message string) {
+	s.setCondition(ReadyConditionType, status, observedGeneration, reason, message)
+}
+
+func (s *SkiperatorStatus) SetStandardRoutingReadyCondition(status metav1.ConditionStatus, observedGeneration int64, reason string, message string) {
+	s.setCondition(StandardRoutingReadyConditionType, status, observedGeneration, reason, message)
+}
+
+func (s *SkiperatorStatus) SetLegacyRoutingActiveCondition(status metav1.ConditionStatus, observedGeneration int64, reason string, message string) {
+	s.setCondition(LegacyRoutingActiveConditionType, status, observedGeneration, reason, message)
 }
 
 func (s *SkiperatorStatus) AddSubResourceStatus(object client.Object, message string, status StatusNames) {

--- a/api/common/status_types_test.go
+++ b/api/common/status_types_test.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetReadyCondition(t *testing.T) {
+	status := &SkiperatorStatus{}
+
+	status.SetReadyCondition(metav1.ConditionFalse, 3, "ValidationFailed", "not ready")
+
+	requirement := meta.FindStatusCondition(status.Conditions, ReadyConditionType)
+	if assert.NotNil(t, requirement) {
+		assert.Equal(t, metav1.ConditionFalse, requirement.Status)
+		assert.Equal(t, int64(3), requirement.ObservedGeneration)
+		assert.Equal(t, "ValidationFailed", requirement.Reason)
+		assert.Equal(t, "not ready", requirement.Message)
+	}
+}
+
+func TestSetStandardRoutingReadyCondition(t *testing.T) {
+	status := &SkiperatorStatus{}
+
+	status.SetStandardRoutingReadyCondition(metav1.ConditionTrue, 4, "StandardRoutingReady", "ready")
+
+	requirement := meta.FindStatusCondition(status.Conditions, StandardRoutingReadyConditionType)
+	if assert.NotNil(t, requirement) {
+		assert.Equal(t, metav1.ConditionTrue, requirement.Status)
+		assert.Equal(t, int64(4), requirement.ObservedGeneration)
+		assert.Equal(t, "StandardRoutingReady", requirement.Reason)
+		assert.Equal(t, "ready", requirement.Message)
+	}
+}
+
+func TestSetLegacyRoutingActiveCondition(t *testing.T) {
+	status := &SkiperatorStatus{}
+
+	status.SetLegacyRoutingActiveCondition(metav1.ConditionTrue, 5, "LegacyRoutingActive", "legacy routing is active")
+
+	requirement := meta.FindStatusCondition(status.Conditions, LegacyRoutingActiveConditionType)
+	if assert.NotNil(t, requirement) {
+		assert.Equal(t, metav1.ConditionTrue, requirement.Status)
+		assert.Equal(t, int64(5), requirement.ObservedGeneration)
+		assert.Equal(t, "LegacyRoutingActive", requirement.Reason)
+		assert.Equal(t, "legacy routing is active", requirement.Message)
+	}
+}

--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -16,10 +16,17 @@ import (
 
 type ApplicationKind string
 
+// RoutingProvider selects which routing API Skiperator generates ingress
+// resources with.
+type RoutingProvider string
+
 // Kind values for the workload skiperator generates for an Application
 const (
 	ApplicationKindDeployment  ApplicationKind = "Deployment"
 	ApplicationKindStatefulSet ApplicationKind = "StatefulSet"
+
+	RoutingProviderLegacy   RoutingProvider = "Legacy"
+	RoutingProviderStandard RoutingProvider = "Standard"
 )
 
 // ApplicationStatus is a specialized status specific to the Application kind.
@@ -51,7 +58,9 @@ type ApplicationList struct {
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:printcolumn:name="AccessPolicies",type=string,JSONPath=`.status.accessPolicies`,priority=1
+// +kubebuilder:printcolumn:name="Routing",type=string,JSONPath=`.spec.routingProvider`
 // +kubebuilder:printcolumn:name="WorkloadType",type=string,JSONPath=`.status.applicationKind`
+// +kubebuilder:selectablefield:JSONPath=".spec.routingProvider"
 type Application struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -94,6 +103,14 @@ type ApplicationSpec struct {
 	// E.g. "foo.atkv3-dev.kartverket-intern.cloud+env-wildcard-cert"
 	//+kubebuilder:validation:Optional
 	Ingresses []string `json:"ingresses,omitempty"`
+
+	// RoutingProvider controls which routing API Skiperator uses for ingresses.
+	// Legacy uses Istio Gateway and VirtualService. Standard uses Kubernetes Gateway API.
+	//
+	//+kubebuilder:validation:Enum=Legacy;Standard
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:default=Legacy
+	RoutingProvider RoutingProvider `json:"routingProvider,omitempty"`
 
 	// An optional priority. Supported values are 'low', 'medium' and 'high'.
 	// The default value is 'medium'.
@@ -461,6 +478,10 @@ func (a *Application) IngressTargetPort() int {
 		}
 	}
 	return a.Spec.Port
+}
+
+func (a *Application) UsesStandardRouting() bool {
+	return a.Spec.RoutingProvider == RoutingProviderStandard
 }
 
 // ResolvePortNumber resolves an IntOrString port to the numeric string value.

--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -48,8 +48,9 @@ type ApplicationList struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName="app"
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.summary.status`
-// +kubebuilder:printcolumn:name="AccessPolicies",type=string,JSONPath=`.status.accessPolicies`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
+// +kubebuilder:printcolumn:name="AccessPolicies",type=string,JSONPath=`.status.accessPolicies`,priority=1
 // +kubebuilder:printcolumn:name="WorkloadType",type=string,JSONPath=`.status.applicationKind`
 type Application struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha1/routing_types.go
+++ b/api/v1alpha1/routing_types.go
@@ -22,7 +22,8 @@ type RoutingList struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName="routing"
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.summary.status`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 type Routing struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -72,6 +73,8 @@ func (in *Routing) GetRedirectToHTTPS() bool {
 	return true
 }
 
+// GetGatewayName returns the legacy Istio Gateway resource name.
+// This does not refer to a Kubernetes Gateway API Gateway.
 func (in *Routing) GetGatewayName() string {
 	return fmt.Sprintf("%s-routing-ingress", in.Name)
 }

--- a/api/v1alpha1/routing_types.go
+++ b/api/v1alpha1/routing_types.go
@@ -24,6 +24,8 @@ type RoutingList struct {
 // +kubebuilder:resource:shortName="routing"
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
+// +kubebuilder:printcolumn:name="Routing",type=string,JSONPath=`.spec.routingProvider`
+// +kubebuilder:selectablefield:JSONPath=".spec.routingProvider"
 type Routing struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -37,6 +39,14 @@ type Routing struct {
 type RoutingSpec struct {
 	//+kubebuilder:validation:Required
 	Hostname string `json:"hostname"`
+
+	// RoutingProvider controls which routing API Skiperator uses.
+	// Legacy uses Istio Gateway and VirtualService. Standard uses Kubernetes Gateway API.
+	//
+	//+kubebuilder:validation:Enum=Legacy;Standard
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:default=Legacy
+	RoutingProvider RoutingProvider `json:"routingProvider,omitempty"`
 
 	//+kubebuilder:validation:Required
 	Routes []Route `json:"routes"`
@@ -71,6 +81,10 @@ func (in *Routing) GetRedirectToHTTPS() bool {
 		return *in.Spec.RedirectToHTTPS
 	}
 	return true
+}
+
+func (in *Routing) UsesStandardRouting() bool {
+	return in.Spec.RoutingProvider == RoutingProviderStandard
 }
 
 // GetGatewayName returns the legacy Istio Gateway resource name.

--- a/api/v1beta1/skipjob_types.go
+++ b/api/v1beta1/skipjob_types.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	commontypes "github.com/kartverket/skiperator/api/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -31,8 +32,9 @@ type SKIPJobStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:object:generate=true
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.summary.status`
-// +kubebuilder:printcolumn:name="AccessPolicies",type=string,JSONPath=`.status.accessPolicies`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
+// +kubebuilder:printcolumn:name="AccessPolicies",type=string,JSONPath=`.status.accessPolicies`,priority=1
 // +kubebuilder:storageversion
 //
 // SKIPJob is the supported schema for the SKIPJobs API.
@@ -200,6 +202,13 @@ func (skipJob *SKIPJob) FillDefaultStatus() {
 
 	if len(skipJob.Status.Conditions) == 0 {
 		skipJob.Status.Conditions = []metav1.Condition{
+			{
+				Type:               commontypes.ReadyConditionType,
+				Status:             metav1.ConditionUnknown,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "NotReconciled",
+				Message:            "SKIPJob has not been reconciled yet",
+			},
 			{
 				Type:               ConditionRunning,
 				Status:             metav1.ConditionFalse,

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -17,11 +17,15 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.summary.status
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
       name: Status
       type: string
     - jsonPath: .status.accessPolicies
       name: AccessPolicies
+      priority: 1
       type: string
     - jsonPath: .status.applicationKind
       name: WorkloadType

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -27,6 +27,9 @@ spec:
       name: AccessPolicies
       priority: 1
       type: string
+    - jsonPath: .spec.routingProvider
+      name: Routing
+      type: string
     - jsonPath: .status.applicationKind
       name: WorkloadType
       type: string
@@ -1899,6 +1902,15 @@ spec:
                       Requests can be set on the CPU and memory.
                     type: object
                 type: object
+              routingProvider:
+                default: Legacy
+                description: |-
+                  RoutingProvider controls which routing API Skiperator uses for ingresses.
+                  Legacy uses Istio Gateway and VirtualService. Standard uses Kubernetes Gateway API.
+                enum:
+                - Legacy
+                - Standard
+                type: string
               startup:
                 description: |-
                   Kubernetes uses startup probes to know when a container application has started.
@@ -2384,6 +2396,8 @@ spec:
             - summary
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.routingProvider
     served: true
     storage: true
     subresources:

--- a/config/crd/skiperator.kartverket.no_routings.yaml
+++ b/config/crd/skiperator.kartverket.no_routings.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].reason
       name: Status
       type: string
+    - jsonPath: .spec.routingProvider
+      name: Routing
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -69,6 +72,15 @@ spec:
                   - targetApp
                   type: object
                 type: array
+              routingProvider:
+                default: Legacy
+                description: |-
+                  RoutingProvider controls which routing API Skiperator uses.
+                  Legacy uses Istio Gateway and VirtualService. Standard uses Kubernetes Gateway API.
+                enum:
+                - Legacy
+                - Standard
+                type: string
             required:
             - hostname
             - routes
@@ -183,6 +195,8 @@ spec:
         required:
         - spec
         type: object
+    selectableFields:
+    - jsonPath: .spec.routingProvider
     served: true
     storage: true
     subresources:

--- a/config/crd/skiperator.kartverket.no_routings.yaml
+++ b/config/crd/skiperator.kartverket.no_routings.yaml
@@ -17,7 +17,10 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.summary.status
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
       name: Status
       type: string
     name: v1alpha1

--- a/config/crd/skiperator.kartverket.no_skipjobs.yaml
+++ b/config/crd/skiperator.kartverket.no_skipjobs.yaml
@@ -1131,11 +1131,15 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - jsonPath: .status.summary.status
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
       name: Status
       type: string
     - jsonPath: .status.accessPolicies
       name: AccessPolicies
+      priority: 1
       type: string
     name: v1beta1
     schema:

--- a/internal/controllers/application.go
+++ b/internal/controllers/application.go
@@ -341,25 +341,30 @@ func (r *ApplicationReconciler) updateApplicationStatus(ctx context.Context, app
 }
 
 func (r *ApplicationReconciler) updateStatus(app *skiperatorv1alpha1.Application) {
-	app.Status.Conditions, app.Status.AccessPolicies = getConditions(app)
+	app.Status.AccessPolicies = applyApplicationConditions(app)
 	app.Status.ApplicationKind = app.ExpectedApplicationKind()
 }
 
-func getConditions(app *skiperatorv1alpha1.Application) ([]metav1.Condition, skiperatorv1alpha1.StatusNames) {
-	var conditions []metav1.Condition
+// applyApplicationConditions merges the access-policy conditions in place
+// (preserving LastTransitionTime). Only invalid config sets Ready here; a valid
+// config leaves Ready to the end of the reconcile, so an early Ready=True cannot
+// mask a later failure.
+func applyApplicationConditions(app *skiperatorv1alpha1.Application) skiperatorv1alpha1.StatusNames {
 	accessPolicy := app.Spec.AccessPolicy
 
 	if accessPolicy != nil && !common.IsInternalRulesValid(accessPolicy) {
-		conditions = append(conditions, common.GetInternalRulesCondition(app, metav1.ConditionFalse))
-		return conditions, skiperatorv1alpha1.INVALIDCONFIG
+		common.SetReadyInvalidConfig(app, "Internal rules are invalid")
+		common.SetInternalRulesCondition(app, metav1.ConditionFalse)
+		return skiperatorv1alpha1.INVALIDCONFIG
 	}
 	if accessPolicy != nil && !common.IsExternalRulesValid(accessPolicy) {
-		conditions = append(conditions, common.GetExternalRulesCondition(app, metav1.ConditionFalse))
-		return conditions, skiperatorv1alpha1.INVALIDCONFIG
+		common.SetReadyInvalidConfig(app, "External rules are invalid")
+		common.SetExternalRulesCondition(app, metav1.ConditionFalse)
+		return skiperatorv1alpha1.INVALIDCONFIG
 	}
-	conditions = append(conditions, common.GetInternalRulesCondition(app, metav1.ConditionTrue))
-	conditions = append(conditions, common.GetExternalRulesCondition(app, metav1.ConditionTrue))
-	return conditions, skiperatorv1alpha1.READY
+	common.SetInternalRulesCondition(app, metav1.ConditionTrue)
+	common.SetExternalRulesCondition(app, metav1.ConditionTrue)
+	return skiperatorv1alpha1.READY
 }
 
 func (r *ApplicationReconciler) getApplication(ctx context.Context, req reconcile.Request) (*skiperatorv1alpha1.Application, error) {

--- a/internal/controllers/application.go
+++ b/internal/controllers/application.go
@@ -319,6 +319,12 @@ func (r *ApplicationReconciler) setSyncedApplicationState(ctx context.Context, a
 	r.EmitNormalEvent(app, "ReconcileEndSuccess", message)
 	app.GetStatus().SetSummarySynced()
 	r.updateStatus(app)
+	// updateStatus only sets Ready for an invalid access policy, so a successful
+	// reconcile has to mark it ready here. The Application reconciler does not go
+	// through ReconcilerBase.SetSyncedState.
+	if app.Status.AccessPolicies != skiperatorv1alpha1.INVALIDCONFIG {
+		common.SetReadyReconciled(app, message)
+	}
 	r.updateApplicationStatus(ctx, app)
 }
 

--- a/internal/controllers/common/reconciler.go
+++ b/internal/controllers/common/reconciler.go
@@ -140,23 +140,27 @@ func (r *ReconcilerBase) SetSubresourceDefaults(resources []client.Object, skipO
 func (r *ReconcilerBase) SetErrorState(ctx context.Context, skipObj common.SKIPObject, err error, message string, reason string) {
 	r.EmitWarningEvent(skipObj, reason, message)
 	skipObj.GetStatus().SetSummaryError(message + ": " + err.Error())
-	r.updateStatus(ctx, skipObj)
+	skipObj.GetStatus().SetReadyCondition(metav1.ConditionFalse, skipObj.GetGeneration(), reason, message+": "+err.Error())
+	r.UpdateStatus(ctx, skipObj)
 }
 
 func (r *ReconcilerBase) SetProgressingState(ctx context.Context, skipObj common.SKIPObject, message string) {
 	r.EmitNormalEvent(skipObj, "ReconcileStart", message)
 	skipObj.GetStatus().SetSummaryProgressing()
-	r.updateStatus(ctx, skipObj)
+	skipObj.GetStatus().SetReadyCondition(metav1.ConditionUnknown, skipObj.GetGeneration(), "Reconciling", message)
+	r.UpdateStatus(ctx, skipObj)
 }
 
 func (r *ReconcilerBase) SetSyncedState(ctx context.Context, skipObj common.SKIPObject, message string) {
 	r.EmitNormalEvent(skipObj, "ReconcileEndSuccess", message)
 	skipObj.GetStatus().SetSummarySynced()
-	r.updateStatus(ctx, skipObj)
+	SetReadyReconciled(skipObj, message)
+	r.UpdateStatus(ctx, skipObj)
 }
 
-func (r *ReconcilerBase) updateStatus(ctx context.Context, skipObj common.SKIPObject) {
+func (r *ReconcilerBase) UpdateStatus(ctx context.Context, skipObj common.SKIPObject) {
 	key := client.ObjectKeyFromObject(skipObj)
+	skipObj.GetStatus().SortConditions()
 	desiredStatus := skipObj.GetStatus().DeepCopy()
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/internal/controllers/common/util.go
+++ b/internal/controllers/common/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kartverket/skiperator/pkg/metrics/usage"
 	"github.com/r3labs/diff/v3"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -118,6 +119,26 @@ func GetExternalRulesCondition(obj common.SKIPObject, status metav1.ConditionSta
 		Reason:             "ApplicationReconciled",
 		Message:            message,
 	}
+}
+
+// SetInternalRulesCondition and SetExternalRulesCondition merge the rules
+// conditions in place via meta.SetStatusCondition, which preserves
+// LastTransitionTime when the status does not change (unlike rebuilding the
+// condition slice from scratch every reconcile).
+func SetInternalRulesCondition(obj common.SKIPObject, status metav1.ConditionStatus) {
+	meta.SetStatusCondition(&obj.GetStatus().Conditions, GetInternalRulesCondition(obj, status))
+}
+
+func SetExternalRulesCondition(obj common.SKIPObject, status metav1.ConditionStatus) {
+	meta.SetStatusCondition(&obj.GetStatus().Conditions, GetExternalRulesCondition(obj, status))
+}
+
+func SetReadyInvalidConfig(obj common.SKIPObject, message string) {
+	obj.GetStatus().SetReadyCondition(metav1.ConditionFalse, obj.GetGeneration(), "InvalidConfig", message)
+}
+
+func SetReadyReconciled(obj common.SKIPObject, message string) {
+	obj.GetStatus().SetReadyCondition(metav1.ConditionTrue, obj.GetGeneration(), "Reconciled", message)
 }
 
 func GetObjectDiff[T any](a T, b T) (diff.Changelog, error) {

--- a/internal/controllers/skipjob.go
+++ b/internal/controllers/skipjob.go
@@ -11,6 +11,7 @@ import (
 
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	commontypes "github.com/kartverket/skiperator/api/common"
 	skiperatorv1beta1 "github.com/kartverket/skiperator/api/v1beta1"
 	"github.com/kartverket/skiperator/internal/controllers/common"
 	"github.com/kartverket/skiperator/pkg/log"
@@ -226,7 +227,9 @@ func (r *SKIPJobReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		return common.RequeueWithError(err)
 	}
 
-	r.SetSyncedState(ctx, skipJob, "SKIPJob has been reconciled")
+	r.EmitNormalEvent(skipJob, "ReconcileEndSuccess", "SKIPJob has been reconciled")
+	skipJob.GetStatus().SetSummarySynced()
+	r.UpdateStatus(ctx, skipJob)
 
 	return common.RequeueWithError(err)
 }
@@ -342,6 +345,17 @@ func (r *SKIPJobReconciler) getConditionFailed(skipJob *skiperatorv1beta1.SKIPJo
 	}
 }
 
+func (r *SKIPJobReconciler) getConditionReady(skipJob *skiperatorv1beta1.SKIPJob, status v1.ConditionStatus, reason string, message string) v1.Condition {
+	return v1.Condition{
+		Type:               commontypes.ReadyConditionType,
+		Status:             status,
+		ObservedGeneration: skipJob.Generation,
+		LastTransitionTime: v1.Now(),
+		Reason:             reason,
+		Message:            message,
+	}
+}
+
 func (r *SKIPJobReconciler) updateConditions(ctx context.Context, skipJob *skiperatorv1beta1.SKIPJob) error {
 	jobList := &batchv1.JobList{}
 	err := r.GetClient().List(ctx, jobList,
@@ -362,24 +376,28 @@ func (r *SKIPJobReconciler) updateConditions(ctx context.Context, skipJob *skipe
 
 	if len(jobList.Items) == 0 {
 		skipJob.Status.Conditions = []v1.Condition{
+			r.getConditionReady(skipJob, v1.ConditionUnknown, "JobPending", "Job has not started yet"),
 			r.getConditionFailed(skipJob, v1.ConditionFalse, nil),
 			r.getConditionRunning(skipJob, v1.ConditionFalse),
 			r.getConditionFinished(skipJob, v1.ConditionFalse),
 		}
 	} else if isFailed, failedJobMessage := isFailedJob(lastJob); isFailed {
 		skipJob.Status.Conditions = []v1.Condition{
+			r.getConditionReady(skipJob, v1.ConditionFalse, "JobFailed", failedJobMessage),
 			r.getConditionFailed(skipJob, v1.ConditionTrue, &failedJobMessage),
 			r.getConditionRunning(skipJob, v1.ConditionFalse),
 			r.getConditionFinished(skipJob, v1.ConditionFalse),
 		}
 	} else if lastJob.Status.CompletionTime != nil {
 		skipJob.Status.Conditions = []v1.Condition{
+			r.getConditionReady(skipJob, v1.ConditionTrue, "JobFinished", "Job has completed"),
 			r.getConditionFailed(skipJob, v1.ConditionFalse, nil),
 			r.getConditionRunning(skipJob, v1.ConditionFalse),
 			r.getConditionFinished(skipJob, v1.ConditionTrue),
 		}
 	} else {
 		skipJob.Status.Conditions = []v1.Condition{
+			r.getConditionReady(skipJob, v1.ConditionUnknown, "JobRunning", "Job is running"),
 			r.getConditionFailed(skipJob, v1.ConditionFalse, nil),
 			r.getConditionRunning(skipJob, v1.ConditionTrue),
 			r.getConditionFinished(skipJob, v1.ConditionFalse),
@@ -390,9 +408,11 @@ func (r *SKIPJobReconciler) updateConditions(ctx context.Context, skipJob *skipe
 	accessPolicy := skipJob.Spec.AccessPolicy
 
 	if accessPolicy != nil && !common.IsInternalRulesValid(accessPolicy) {
+		skipJob.GetStatus().SetReadyCondition(v1.ConditionFalse, skipJob.GetGeneration(), "InvalidConfig", "Internal rules are invalid")
 		skipJob.Status.Conditions = append(skipJob.Status.Conditions, common.GetInternalRulesCondition(skipJob, v1.ConditionFalse))
 		skipJob.Status.AccessPolicies = skiperatorv1beta1.INVALIDCONFIG
 	} else if accessPolicy != nil && !common.IsExternalRulesValid(accessPolicy) {
+		skipJob.GetStatus().SetReadyCondition(v1.ConditionFalse, skipJob.GetGeneration(), "InvalidConfig", "External rules are invalid")
 		skipJob.Status.Conditions = append(skipJob.Status.Conditions, common.GetExternalRulesCondition(skipJob, v1.ConditionFalse))
 		skipJob.Status.AccessPolicies = skiperatorv1beta1.INVALIDCONFIG
 	} else {

--- a/tests/application/access-policy/advanced-assert.yaml
+++ b/tests/application/access-policy/advanced-assert.yaml
@@ -128,6 +128,9 @@ spec:
 status:
   accessPolicies: Ready
   conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
     - type: InternalRulesValid
       status: "True"
     - type: ExternalRulesValid

--- a/tests/application/access-policy/advanced-error.yaml
+++ b/tests/application/access-policy/advanced-error.yaml
@@ -31,6 +31,9 @@ spec:
               protocol: TCP
 status:
   conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
     - type: InternalRulesValid
       status: "True"
     - type: ExternalRulesValid

--- a/tests/application/access-policy/bad-policy-assert.yaml
+++ b/tests/application/access-policy/bad-policy-assert.yaml
@@ -12,6 +12,9 @@ spec:
 status:
   accessPolicies: InvalidConfig
   conditions:
+    - type: Ready
+      status: "False"
+      reason: InvalidConfig
     - type: InternalRulesValid
       status: "False"
 ---
@@ -39,6 +42,9 @@ spec:
           namespace: non-existing
 status:
   conditions:
+    - type: Ready
+      status: "False"
+      reason: InvalidConfig
     - type: InternalRulesValid
       status: "False"
 ---
@@ -67,6 +73,9 @@ spec:
           application: access-policy-other
 status:
   conditions:
+    - type: Ready
+      status: "False"
+      reason: InvalidConfig
     - type: InternalRulesValid
       status: "False"
 ---

--- a/tests/application/access-policy/external-blank-hostname-assert.yaml
+++ b/tests/application/access-policy/external-blank-hostname-assert.yaml
@@ -14,6 +14,9 @@ spec:
 status:
   accessPolicies: InvalidConfig
   conditions:
+    - type: Ready
+      status: "False"
+      reason: InvalidConfig
     - type: ExternalRulesValid
       message: External rules are invalid – hostname may be empty or duplicate, or the hostname may not be a valid DNS name
       reason: ApplicationReconciled

--- a/tests/application/access-policy/only-unique-hosts-assert.yaml
+++ b/tests/application/access-policy/only-unique-hosts-assert.yaml
@@ -24,6 +24,9 @@ status:
   accessPolicies: InvalidConfig
   conditions:
     - status: "False"
+      reason: InvalidConfig
+      type: Ready
+    - status: "False"
       message: "External rules are invalid – hostname may be empty or duplicate, or the hostname may not be a valid DNS name"
       type: ExternalRulesValid
 ---
@@ -49,6 +52,9 @@ spec:
 status:
   accessPolicies: Ready
   conditions:
+    - status: "True"
+      reason: Reconciled
+      type: Ready
     - status: "True"
       type: InternalRulesValid
     - status: "True"

--- a/tests/application/subresource-status/application-resource-apply-error-assert.yaml
+++ b/tests/application/subresource-status/application-resource-apply-error-assert.yaml
@@ -17,7 +17,10 @@ spec:
   strategy:
     type: RollingUpdate
 status:
-  conditions: []
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: ProcessorFailure
   subresources:
     AuthorizationPolicy[badport-default-deny]:
       message: AuthorizationPolicy has finished synchronizing

--- a/tests/skipjob/access-policy-job/skipjob-assert.yaml
+++ b/tests/skipjob/access-policy-job/skipjob-assert.yaml
@@ -93,12 +93,15 @@ spec:
 status:
   accessPolicies: Ready
   conditions:
+    - type: Ready
+      status: "True"
+      reason: JobFinished
     - type: Failed
       status: "False"
     - type: Running
-      status: "True"
-    - type: Finished
       status: "False"
+    - type: Finished
+      status: "True"
     - type: InternalRulesValid
       status: "True"
     - type: ExternalRulesValid

--- a/tests/skipjob/access-policy-job/skipjob-cron-assert.yaml
+++ b/tests/skipjob/access-policy-job/skipjob-cron-assert.yaml
@@ -26,6 +26,9 @@ spec:
 status:
   accessPolicies: Ready
   conditions:
+    - type: Ready
+      status: "Unknown"
+      reason: JobRunning
     - type: Failed
       status: "False"
     - type: Running

--- a/tests/skipjob/access-policy-job/skipjob-cron-error.yaml
+++ b/tests/skipjob/access-policy-job/skipjob-cron-error.yaml
@@ -28,6 +28,9 @@ spec:
     schedule: "* * * * *"
 status:
   conditions:
+    - type: Ready
+      status: "Unknown"
+      reason: JobRunning
     - type: Failed
       status: "False"
     - type: Running

--- a/tests/skipjob/access-policy-job/skipjob-error.yaml
+++ b/tests/skipjob/access-policy-job/skipjob-error.yaml
@@ -26,12 +26,15 @@ spec:
                 protocol: TCP
 status:
   conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
     - type: Failed
       status: "False"
     - type: Running
-      status: "True"
-    - type: Finished
       status: "False"
+    - type: Finished
+      status: "True"
     - type: InternalRulesValid
       status: "True"
     - type: ExternalRulesValid

--- a/tests/skipjob/access-policy-job/status-ready-no-job-assert.yaml
+++ b/tests/skipjob/access-policy-job/status-ready-no-job-assert.yaml
@@ -5,6 +5,9 @@ metadata:
 status:
   accessPolicies: Ready
   conditions:
+    - type: Ready
+      status: 'Unknown'
+      reason: JobPending
     - type: Failed
       status: 'False'
     - type: Running

--- a/tests/skipjob/conditions/skipjob-assert.yaml
+++ b/tests/skipjob/conditions/skipjob-assert.yaml
@@ -5,6 +5,9 @@ metadata:
 status:
   accessPolicies: Ready
   conditions:
+    - type: Ready
+      status: "True"
+      reason: JobFinished
     - type: Failed
       status: "False"
     - type: Running
@@ -23,6 +26,9 @@ metadata:
 status:
   accessPolicies: Ready
   conditions:
+    - type: Ready
+      status: "Unknown"
+      reason: JobRunning
     - type: Failed
       status: "False"
     - type: Running
@@ -41,6 +47,9 @@ metadata:
 status:
   accessPolicies: InvalidConfig
   conditions:
+    - type: Ready
+      status: "False"
+      reason: InvalidConfig
     - type: Failed
       status: "True"
     - type: Running

--- a/tests/skipjob/immutable-container/skipjob-assert.yaml
+++ b/tests/skipjob/immutable-container/skipjob-assert.yaml
@@ -21,6 +21,10 @@ status:
       message: ServiceAccount has finished synchronizing
       status: Synced
   conditions:
+    - message: Job has completed
+      reason: JobFinished
+      status: 'True'
+      type: Ready
     - message: Job failed previous run
       reason: JobFailed
       status: 'False'


### PR DESCRIPTION
Layer 3 of 9. Part of the stack that replaces #884. Builds on #934.

SKIP-1313

## What this does

Two API changes, neither of which changes how any resource is generated.

### A Ready condition on every object

Applications, Routings and SKIPJobs reported progress only through
`status.summary`, a Skiperator-specific shape that no standard tool understands.
`kubectl wait`, ArgoCD health checks and Flux all look for a `Ready` condition, so
none of them could tell a reconciled object from a failed one.

Every status transition now also writes `Ready`:

| Transition | Status | Reason |
|---|---|---|
| Error | `False` | the event reason |
| Progressing | `Unknown` | `Reconciling` |
| Synced | `True` | `Reconciled` |
| Invalid access policy | `False` | `InvalidConfig` |

SKIPJob takes `Ready` from the job itself: `Unknown` while pending or running,
`True` when finished, `False` when failed.

Conditions are merged with `meta.SetStatusCondition` instead of being rebuilt each
reconcile, so `LastTransitionTime` now means what it says. The merge appends in
first-seen order, which makes the stored order depend on reconcile history, so
conditions are sorted into a fixed order before they are persisted.

`Ready` is the first printer column for all three kinds. `Status` now shows the
`Ready` reason instead of the summary, and `AccessPolicies` moves behind `-o wide`.

### spec.routingProvider

The field that selects between Istio routing and Kubernetes Gateway API routing.
`Legacy` is the default, so existing objects keep generating Istio `Gateway` and
`VirtualService` resources and nothing changes for them.

Nothing reads the field yet. The generators and the reconcilers come in the layers
above this one. The field is a selectable field, so operators can list what a
cluster still has on `Legacy` with a field selector instead of a client-side sweep.

## Review notes

The chainsaw assertion changes are all the new `Ready` condition. Worth checking
that the expected reason on each is the one you would want to see in `kubectl get`.

