### PR TITLE
feat(metrics): report routing provider and stalled migrations

### DIFF
--- a/cmd/skiperator/main.go
+++ b/cmd/skiperator/main.go
@@ -185,11 +185,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Signal-driven context shared by the usage-metrics goroutine and the
+	// manager, so background work stops cleanly on shutdown.
+	signalCtx := ctrl.SetupSignalHandler()
+
 	// Run leader-specific tasks when elected
 	go func() {
-		<-mgr.Elected() // Wait until this instance is elected as leader
+		select {
+		case <-mgr.Elected(): // Wait until this instance is elected as leader
+		case <-signalCtx.Done():
+			return
+		}
 		setupLog.Info("I am the captain now – configuring usage metrics")
-		if err := usage.NewUsageMetrics(kubeconfig, log.NewLogger().WithName("usage-metrics")); err != nil {
+		if err := usage.NewUsageMetrics(signalCtx, kubeconfig, log.NewLogger().WithName("usage-metrics")); err != nil {
 			setupLog.Error(err, "unable to configure usage metrics")
 		}
 	}()
@@ -298,7 +306,7 @@ func main() {
 		os.Exit(1)
 	}
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(signalCtx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/pkg/metrics/usage/constants.go
+++ b/pkg/metrics/usage/constants.go
@@ -9,7 +9,8 @@ const (
 	labelDivision = "division"
 
 	// CRD label
-	labelType = "type"
+	labelType            = "type"
+	labelRoutingProvider = "provider"
 
 	// Skiperator CRD types
 	typeApplication = "Application"

--- a/pkg/metrics/usage/namespace.go
+++ b/pkg/metrics/usage/namespace.go
@@ -1,12 +1,7 @@
 package usage
 
 import (
-	"context"
-
-	"github.com/kartverket/skiperator/pkg/log"
 	"github.com/prometheus/client_golang/prometheus"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func init() {
@@ -19,35 +14,17 @@ func init() {
 	registerGaugeVecFunc(metadata, labels, updateNamespace)
 }
 
-func updateNamespace(ctx context.Context, k client.Client, logger log.Logger, currentGauge *prometheus.GaugeVec) {
-	namespaces := &corev1.NamespaceList{}
-	if err := k.List(ctx, namespaces); err != nil {
-		logger.Error(err, "failed to list namespaces")
-		return
+func updateNamespace(usage clusterUsage, currentGauge *prometheus.GaugeVec) {
+	counts := make(map[namespaceLabels]float64)
+	for _, namespace := range usage.namespaces {
+		counts[namespace]++
 	}
 
-	counts := make(map[string]map[string]float64)
-
-	// Count namespaces grouped by label combination
-	for _, ns := range namespaces.Items {
-		team := ns.Labels[labelTeam]
-		division := ns.Labels[labelDivision]
-
-		key := valueOrDefault(team) + "|" + valueOrDefault(division)
-		if counts[key] == nil {
-			counts[key] = map[string]float64{}
-		}
-		counts[key][countKey]++ // Increment count
-	}
-
-	// Reset and update metrics
 	currentGauge.Reset()
-	for key := range counts {
-		labels := map[string]string{}
-		parts := splitKey(key)
-		labels[labelTeam] = parts[0]
-		labels[labelDivision] = parts[1]
-
-		currentGauge.With(labels).Set(counts[key][countKey])
+	for key, count := range counts {
+		currentGauge.With(prometheus.Labels{
+			labelTeam:     key.team,
+			labelDivision: key.division,
+		}).Set(count)
 	}
 }

--- a/pkg/metrics/usage/routing_migration.go
+++ b/pkg/metrics/usage/routing_migration.go
@@ -1,0 +1,60 @@
+package usage
+
+import (
+	commontypes "github.com/kartverket/skiperator/api/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type routingMigrationMetricKey struct {
+	team     string
+	division string
+	kind     string
+}
+
+func init() {
+	metadata := prometheus.GaugeOpts{
+		Subsystem: metricSubsystem,
+		Name:      "routing_migration_stalled",
+		Help:      "Number of active routable CRs with stalled Gateway API migration",
+	}
+	labels := []string{labelTeam, labelDivision, labelType}
+	registerGaugeVecFunc(metadata, labels, updateRoutingMigrationStalled)
+}
+
+func updateRoutingMigrationStalled(usage clusterUsage, currentGauge *prometheus.GaugeVec) {
+	counts := make(map[routingMigrationMetricKey]float64)
+	usage.routables(func(resource usageResource) {
+		if !hasStalledRoutingMigration(resource.item) {
+			return
+		}
+		counts[routingMigrationMetricKey{team: resource.team, division: resource.division, kind: resource.kind}]++
+	})
+
+	currentGauge.Reset()
+	for key, count := range counts {
+		currentGauge.With(prometheus.Labels{
+			labelTeam:     key.team,
+			labelDivision: key.division,
+			labelType:     key.kind,
+		}).Set(count)
+	}
+}
+
+func hasStalledRoutingMigration(obj unstructured.Unstructured) bool {
+	conditions, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	for _, condition := range conditions {
+		conditionMap, ok := condition.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		conditionType, _, _ := unstructured.NestedString(conditionMap, "type")
+		reason, _, _ := unstructured.NestedString(conditionMap, "reason")
+		// Ready can also use MigrationStalled. Count only the Gateway API
+		// routing condition so the metric tracks migration health specifically.
+		if conditionType == commontypes.StandardRoutingReadyConditionType && reason == commontypes.MigrationStalledReason {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/metrics/usage/routing_migration_test.go
+++ b/pkg/metrics/usage/routing_migration_test.go
@@ -1,0 +1,49 @@
+package usage
+
+import (
+	"testing"
+
+	commontypes "github.com/kartverket/skiperator/api/common"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestHasStalledRoutingMigration(t *testing.T) {
+	obj := unstructured.Unstructured{Object: map[string]interface{}{
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				// Real stalled migrations set Ready and StandardRoutingReady.
+				map[string]interface{}{
+					"type":   commontypes.ReadyConditionType,
+					"reason": commontypes.MigrationStalledReason,
+				},
+				map[string]interface{}{
+					"type":   commontypes.StandardRoutingReadyConditionType,
+					"reason": commontypes.MigrationStalledReason,
+				},
+			},
+		},
+	}}
+
+	assert.True(t, hasStalledRoutingMigration(obj))
+}
+
+func TestHasStalledRoutingMigrationIgnoresReadyOnlyStalledCondition(t *testing.T) {
+	obj := unstructured.Unstructured{Object: map[string]interface{}{
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				// Ready alone is not enough; metric must key off StandardRoutingReady.
+				map[string]interface{}{
+					"type":   commontypes.ReadyConditionType,
+					"reason": commontypes.MigrationStalledReason,
+				},
+				map[string]interface{}{
+					"type":   commontypes.StandardRoutingReadyConditionType,
+					"reason": "StandardRoutingNotReady",
+				},
+			},
+		},
+	}}
+
+	assert.False(t, hasStalledRoutingMigration(obj))
+}

--- a/pkg/metrics/usage/routing_provider.go
+++ b/pkg/metrics/usage/routing_provider.go
@@ -1,0 +1,56 @@
+package usage
+
+import (
+	"github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type routingProviderMetricKey struct {
+	team            string
+	division        string
+	kind            string
+	routingProvider string
+}
+
+func init() {
+	metadata := prometheus.GaugeOpts{
+		Subsystem: metricSubsystem,
+		Name:      "routing_provider_usage",
+		Help:      "Number of active routable CRs by routing provider",
+	}
+	labels := []string{labelTeam, labelDivision, labelType, labelRoutingProvider}
+	registerGaugeVecFunc(metadata, labels, updateRoutingProviderUsage)
+}
+
+func updateRoutingProviderUsage(usage clusterUsage, currentGauge *prometheus.GaugeVec) {
+	counts := make(map[routingProviderMetricKey]float64)
+	usage.routables(func(resource usageResource) {
+		counts[routingProviderMetricKey{
+			team:            resource.team,
+			division:        resource.division,
+			kind:            resource.kind,
+			routingProvider: routingProviderFromObject(resource.item),
+		}]++
+	})
+
+	currentGauge.Reset()
+	for key, count := range counts {
+		currentGauge.With(prometheus.Labels{
+			labelTeam:            key.team,
+			labelDivision:        key.division,
+			labelType:            key.kind,
+			labelRoutingProvider: key.routingProvider,
+		}).Set(count)
+	}
+}
+
+// routingProviderFromObject reads spec.routingProvider, defaulting to Legacy for
+// objects written before the field existed.
+func routingProviderFromObject(obj unstructured.Unstructured) string {
+	provider, _, _ := unstructured.NestedString(obj.Object, "spec", "routingProvider")
+	if provider == "" {
+		return string(v1alpha1.RoutingProviderLegacy)
+	}
+	return provider
+}

--- a/pkg/metrics/usage/sweep.go
+++ b/pkg/metrics/usage/sweep.go
@@ -1,0 +1,109 @@
+package usage
+
+import (
+	"context"
+
+	"github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/api/v1beta1"
+	"github.com/kartverket/skiperator/pkg/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Every computed gauge counts the same two things: namespaces and Skiperator
+// CRs. Collecting that once per tick keeps the API traffic at one List per
+// namespace plus one List per kind, no matter how many gauges are registered.
+
+// sweptKinds are the Skiperator CRs the gauges count. Listed cluster-wide, not
+// per namespace.
+var sweptKinds = []struct {
+	groupVersion schema.GroupVersion
+	kind         string
+}{
+	{v1alpha1.GroupVersion, typeApplication},
+	{v1alpha1.GroupVersion, typeRouting},
+	{v1beta1.GroupVersion, typeSKIPJob},
+}
+
+// namespaceLabels holds the organizational labels copied from a namespace.
+type namespaceLabels struct {
+	team     string
+	division string
+}
+
+// usageResource is one Skiperator CR plus the labels of the namespace it lives
+// in, so gauges never have to look the namespace up again.
+type usageResource struct {
+	item     unstructured.Unstructured
+	kind     string
+	team     string
+	division string
+}
+
+// clusterUsage is one snapshot of what the gauges count.
+type clusterUsage struct {
+	namespaces []namespaceLabels
+	resources  []usageResource
+}
+
+// collectClusterUsage lists namespaces and every swept kind once. It reports
+// ok=false when namespaces cannot be listed, since every gauge is keyed by
+// namespace labels and stale gauge values beat wrong ones.
+func collectClusterUsage(ctx context.Context, k client.Client, logger log.Logger) (clusterUsage, bool) {
+	namespaces := &corev1.NamespaceList{}
+	if err := k.List(ctx, namespaces); err != nil {
+		logger.Error(err, "failed to list namespaces")
+		return clusterUsage{}, false
+	}
+
+	usage := clusterUsage{namespaces: make([]namespaceLabels, 0, len(namespaces.Items))}
+	labelsByNamespace := make(map[string]namespaceLabels, len(namespaces.Items))
+	for _, ns := range namespaces.Items {
+		labels := namespaceLabels{
+			team:     valueOrDefault(ns.Labels[labelTeam]),
+			division: valueOrDefault(ns.Labels[labelDivision]),
+		}
+		labelsByNamespace[ns.Name] = labels
+		usage.namespaces = append(usage.namespaces, labels)
+	}
+
+	for _, swept := range sweptKinds {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(swept.groupVersion.WithKind(swept.kind + "List"))
+		if err := k.List(ctx, list); err != nil {
+			// Returning a partial snapshot would let updateMetrics reset this
+			// kind's gauges to zero, which reads as "no resources" rather than
+			// "not measured". Keep the previous values instead.
+			logger.Error(err, "failed to list resources", "kind", swept.kind)
+			return clusterUsage{}, false
+		}
+		for _, item := range list.Items {
+			labels, ok := labelsByNamespace[item.GetNamespace()]
+			if !ok {
+				// Namespace appeared between the namespace and resource list calls;
+				// fall back to defaults instead of empty label values.
+				labels = namespaceLabels{team: unknownValue, division: unknownValue}
+			}
+			usage.resources = append(usage.resources, usageResource{
+				item:     item,
+				kind:     swept.kind,
+				team:     labels.team,
+				division: labels.division,
+			})
+		}
+	}
+	return usage, true
+}
+
+// routables iterates the CRs that carry a routing provider. SKIPJob has no
+// ingress, so it is not one of them.
+func (u clusterUsage) routables(fn func(resource usageResource)) {
+	for _, resource := range u.resources {
+		if resource.kind == typeSKIPJob {
+			continue
+		}
+		fn(resource)
+	}
+}

--- a/pkg/metrics/usage/sweep_test.go
+++ b/pkg/metrics/usage/sweep_test.go
@@ -1,0 +1,100 @@
+package usage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kartverket/skiperator/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func namespaceWithLabels(name string, team string, division string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   name,
+		Labels: map[string]string{labelTeam: team, labelDivision: division},
+	}}
+}
+
+func routable(apiVersion string, kind string, namespace string, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   map[string]interface{}{"name": name, "namespace": namespace},
+	}}
+}
+
+// One sweep must cost one List per namespace collection plus one per swept kind,
+// no matter how many gauges consume it. A per-namespace fan-out regression shows
+// up here as a higher count.
+func TestCollectClusterUsageListsEachKindOnce(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	lists := 0
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			namespaceWithLabels("team-a-main", "team-a", "division-1"),
+			namespaceWithLabels("team-b-main", "team-b", "division-2"),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "unlabelled"}},
+		).
+		WithLists(&unstructured.UnstructuredList{
+			Object: map[string]interface{}{"apiVersion": "skiperator.kartverket.no/v1alpha1", "kind": "ApplicationList"},
+			Items: []unstructured.Unstructured{
+				*routable("skiperator.kartverket.no/v1alpha1", "Application", "team-a-main", "app-one"),
+				*routable("skiperator.kartverket.no/v1alpha1", "Application", "team-a-main", "app-two"),
+				*routable("skiperator.kartverket.no/v1alpha1", "Application", "unlabelled", "app-three"),
+			},
+		}).
+		WithLists(&unstructured.UnstructuredList{
+			Object: map[string]interface{}{"apiVersion": "skiperator.kartverket.no/v1alpha1", "kind": "RoutingList"},
+			Items: []unstructured.Unstructured{
+				*routable("skiperator.kartverket.no/v1alpha1", "Routing", "team-b-main", "routing-one"),
+			},
+		}).
+		WithLists(&unstructured.UnstructuredList{
+			Object: map[string]interface{}{"apiVersion": "skiperator.kartverket.no/v1beta1", "kind": "SKIPJobList"},
+			Items: []unstructured.Unstructured{
+				*routable("skiperator.kartverket.no/v1beta1", "SKIPJob", "team-b-main", "job-one"),
+			},
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				lists++
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	usage, ok := collectClusterUsage(context.Background(), c, log.NewLogger())
+
+	require.True(t, ok)
+	assert.Equal(t, 1+len(sweptKinds), lists, "expected one List for namespaces plus one per swept kind")
+	assert.Len(t, usage.namespaces, 3)
+	require.Len(t, usage.resources, 5)
+
+	// Namespace labels are attached to each resource, and a namespace without
+	// them falls back to the unknown value rather than an empty label.
+	byName := map[string]usageResource{}
+	for _, resource := range usage.resources {
+		byName[resource.item.GetName()] = resource
+	}
+	assert.Equal(t, "team-a", byName["app-one"].team)
+	assert.Equal(t, "division-1", byName["app-one"].division)
+	assert.Equal(t, typeApplication, byName["app-one"].kind)
+	assert.Equal(t, unknownValue, byName["app-three"].team)
+	assert.Equal(t, typeSKIPJob, byName["job-one"].kind)
+
+	// SKIPJob has no ingress, so routing gauges must not see it.
+	routableKinds := map[string]int{}
+	usage.routables(func(resource usageResource) { routableKinds[resource.kind]++ })
+	assert.Equal(t, map[string]int{typeApplication: 3, typeRouting: 1}, routableKinds)
+}

--- a/pkg/metrics/usage/team.go
+++ b/pkg/metrics/usage/team.go
@@ -1,22 +1,13 @@
 package usage
 
 import (
-	"context"
-
-	"github.com/kartverket/skiperator/api/v1alpha1"
-	"github.com/kartverket/skiperator/api/v1beta1"
-	"github.com/kartverket/skiperator/pkg/log"
 	"github.com/prometheus/client_golang/prometheus"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var crdGVRs = []schema.GroupVersionResource{
-	v1alpha1.GroupVersion.WithResource(typeApplication),
-	v1beta1.GroupVersion.WithResource(typeSKIPJob),
-	v1alpha1.GroupVersion.WithResource(typeRouting),
+type teamMetricKey struct {
+	team     string
+	division string
+	kind     string
 }
 
 func init() {
@@ -29,54 +20,18 @@ func init() {
 	registerGaugeVecFunc(metadata, labels, updateTeamCRUsage)
 }
 
-func updateTeamCRUsage(ctx context.Context, k client.Client, logger log.Logger, currentGauge *prometheus.GaugeVec) {
-	// List all namespaces
-	namespaces := &corev1.NamespaceList{}
-	if err := k.List(ctx, namespaces); err != nil {
-		logger.Error(err, "failed to list namespaces")
-		return
+func updateTeamCRUsage(usage clusterUsage, currentGauge *prometheus.GaugeVec) {
+	counts := make(map[teamMetricKey]float64)
+	for _, resource := range usage.resources {
+		counts[teamMetricKey{team: resource.team, division: resource.division, kind: resource.kind}]++
 	}
 
-	// Initialize counts
-	counts := make(map[string]map[string]float64)
-
-	// Iterate over namespaces
-	for _, ns := range namespaces.Items {
-		team := ns.Labels[labelTeam]
-		division := ns.Labels[labelDivision]
-
-		key := valueOrDefault(team) + "|" + valueOrDefault(division)
-		if counts[key] == nil {
-			counts[key] = make(map[string]float64)
-		}
-
-		// Count instances of each CRD in the namespace
-		for _, gvr := range crdGVRs {
-			list := &unstructured.UnstructuredList{}
-			list.SetGroupVersionKind(gvr.GroupVersion().WithKind(gvr.Resource + "List"))
-
-			if err := k.List(ctx, list, client.InNamespace(ns.Name)); err != nil {
-				logger.Error(err, "failed to list resources for", "gvr", gvr, "namespace", ns.Name)
-				continue
-			}
-
-			counts[key][gvr.Resource] += float64(len(list.Items))
-		}
-	}
-
-	// Reset and update metrics
 	currentGauge.Reset()
-	for key, metrics := range counts {
-		parts := splitKey(key)
-		team := parts[0]
-		division := parts[1]
-
-		for resourceType, count := range metrics {
-			currentGauge.With(prometheus.Labels{
-				labelTeam:     team,
-				labelDivision: division,
-				labelType:     resourceType,
-			}).Set(count)
-		}
+	for key, count := range counts {
+		currentGauge.With(prometheus.Labels{
+			labelTeam:     key.team,
+			labelDivision: key.division,
+			labelType:     key.kind,
+		}).Set(count)
 	}
 }

--- a/pkg/metrics/usage/usage.go
+++ b/pkg/metrics/usage/usage.go
@@ -2,7 +2,6 @@ package usage
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/kartverket/skiperator/pkg/log"
@@ -25,8 +24,9 @@ var (
 )
 
 // updateGaugeFunc is a function that will be called when it's time to
-// update the gauge.
-type updateGaugeFunc = func(ctx context.Context, k client.Client, logger log.Logger, currentGauge *prometheus.GaugeVec)
+// update the gauge. It counts from the tick's clusterUsage snapshot rather than
+// listing anything itself, so registering another gauge costs no API calls.
+type updateGaugeFunc = func(usage clusterUsage, currentGauge *prometheus.GaugeVec)
 
 // computableGauge is a struct that holds a gauge and a function to update
 // it in order to make it easier to do bookkeeping
@@ -35,8 +35,9 @@ type computableGauge struct {
 	fn    updateGaugeFunc
 }
 
-// NewUsageMetrics initializes the usage metrics subsystem, ensuring that metrics will be updated
-func NewUsageMetrics(k8sConfig *rest.Config, log log.Logger) error {
+// NewUsageMetrics initializes the usage metrics subsystem, ensuring that metrics will be updated.
+// The refresh goroutine runs until ctx is cancelled, so it stops on manager shutdown / loss of leadership.
+func NewUsageMetrics(ctx context.Context, k8sConfig *rest.Config, log log.Logger) error {
 	if k8sConfig == nil {
 		return errors.New("missing k8s REST config")
 	}
@@ -64,10 +65,15 @@ func NewUsageMetrics(k8sConfig *rest.Config, log log.Logger) error {
 		// regular update
 		ticker := time.NewTicker(metricsRefreshInterval)
 		defer ticker.Stop()
-		for range ticker.C {
-			ctx, cancel := apiserverCtx()
-			updateMetrics(ctx)
-			cancel()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				tickCtx, cancel := apiserverCtx()
+				updateMetrics(tickCtx)
+				cancel()
+			}
 		}
 	}()
 
@@ -76,8 +82,12 @@ func NewUsageMetrics(k8sConfig *rest.Config, log log.Logger) error {
 
 func updateMetrics(ctx context.Context) {
 	logger.Debug("refreshing data and updating metrics")
+	usage, ok := collectClusterUsage(ctx, *kclient, logger)
+	if !ok {
+		return
+	}
 	for _, g := range gauges {
-		g.fn(ctx, *kclient, logger, g.gauge)
+		g.fn(usage, g.gauge)
 	}
 }
 
@@ -87,18 +97,6 @@ func registerGaugeVecFunc(opts prometheus.GaugeOpts, labelNames []string, fn upd
 	g := prometheus.NewGaugeVec(opts, labelNames)
 	metrics.Registry.MustRegister(g)
 	gauges[opts.Name] = computableGauge{gauge: g, fn: fn}
-}
-
-// Helper function to split key back into label values
-func splitKey(key string) []string {
-	parts := [2]string{unknownValue, unknownValue}
-	if key == "" {
-		return parts[:]
-	}
-
-	split := strings.SplitN(key, "|", 2)
-	copy(parts[:], split)
-	return parts[:]
 }
 
 // Ensure empty string if label is missing to avoid "no metric for label set" errors


### PR DESCRIPTION
Layer 5 of 9. Part of the stack that replaces #884. Builds on #936.

SKIP-1313

## What this does

Two gauges for driving the Gateway API migration:

- how many Applications and Routings sit on each routing provider
- how many are stuck part-way through a migration

Stalled is counted from the same `MigrationStalledReason` that `pkg/gwapi` writes,
so the metric and the object status cannot disagree.

## Why the sweep was reworked

Adding the gauges the old way would have doubled the API traffic. Every gauge
listed namespaces itself and then listed each CRD per namespace, so each new gauge
cost a full sweep. Gauges now count from one `clusterUsage` snapshot collected once
per tick: one List for namespaces plus one cluster-wide List per kind, no matter how
many gauges are registered.

## A failed List no longer zeroes the gauges

Zero reads as "there are none" on a dashboard, which is a different claim from "this
was not measured". It would also fire migration alerts during an API server blip.
The tick is abandoned and the previous values are kept instead.

The refresh goroutine now stops on the manager's signal context rather than running
until the process dies, so it goes away on shutdown and on loss of leadership.

