### PR TITLE
feat(gatewayapi): reject Istio retries with Standard routing

### DIFF
--- a/api-docs.md
+++ b/api-docs.md
@@ -2609,7 +2609,7 @@ By default, tracing is enabled with a random sampling percentage of 10%.
         <td><b><a href="#applicationspecistiosettingsretries">retries</a></b></td>
         <td>object</td>
         <td>
-          Retries is configurable automatic retries for requests towards the application.<br/>By default requests falling under: &#34;connect-failure,refused-stream,unavailable,cancelled&#34; will be retried.<br/>
+          Retries is configurable automatic retries for requests towards the application.<br/>By default requests falling under: &#34;connect-failure,refused-stream,unavailable,cancelled&#34; will be retried.<br/><br/>Retries require spec.routingProvider=Legacy. Gateway API serves HTTPRoute<br/>retries only on its experimental channel, which SKIP clusters do not install,<br/>so an Application that asks for both retries and Standard routing is rejected<br/>instead of losing its retry policy.<br/>
         </td>
         <td>false</td>
       </tr>
@@ -2632,6 +2632,11 @@ By default, tracing is enabled with a random sampling percentage of 10%.
 
 Retries is configurable automatic retries for requests towards the application.
 By default requests falling under: "connect-failure,refused-stream,unavailable,cancelled" will be retried.
+
+Retries require spec.routingProvider=Legacy. Gateway API serves HTTPRoute
+retries only on its experimental channel, which SKIP clusters do not install,
+so an Application that asks for both retries and Standard routing is rejected
+instead of losing its retry policy.
 
 <table>
     <thead>

--- a/api/common/istiotypes/istio_settings.go
+++ b/api/common/istiotypes/istio_settings.go
@@ -36,6 +36,11 @@ type Telemetry struct {
 // Retries is configurable automatic retries for requests towards the application.
 // By default requests falling under: "connect-failure,refused-stream,unavailable,cancelled" will be retried.
 //
+// Retries require spec.routingProvider=Legacy. Gateway API serves HTTPRoute
+// retries only on its experimental channel, which SKIP clusters do not install,
+// so an Application that asks for both retries and Standard routing is rejected
+// instead of losing its retry policy.
+//
 // +kubebuilder:object:generate=true
 type Retries struct {
 	// Attempts is the number of retries to be allowed for a given request before giving up. The interval between retries will be determined automatically (25ms+).

--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -75,6 +75,7 @@ type Application struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.extraContainers) || self.extraContainers.all(c, self.extraContainers.filter(x, x.name == c.name).size() == 1)",message="extraContainers names must be unique"
 // +kubebuilder:validation:XValidation:rule="!has(self.extraContainers) || self.extraContainers.filter(c, has(c.ingressPort)).size() <= 1",message="at most one extra container may set ingressPort"
 // +kubebuilder:validation:XValidation:rule="!has(self.extraContainers) || self.extraContainers.all(c, !has(c.ingressPort) || c.ingressPort != self.port)",message="extraContainers ingressPort must differ from spec.port"
+// +kubebuilder:validation:XValidation:rule="self.routingProvider != 'Standard' || !has(self.istioSettings) || !has(self.istioSettings.retries)",message="spec.istioSettings.retries is not supported with spec.routingProvider=Standard, since Gateway API serves HTTPRoute retries only on its experimental channel"
 type ApplicationSpec struct {
 	// The image the application will run. This image will be added to a Deployment resource
 	//

--- a/config/crd/skiperator.kartverket.no_applications.yaml
+++ b/config/crd/skiperator.kartverket.no_applications.yaml
@@ -1346,6 +1346,11 @@ spec:
                     description: |-
                       Retries is configurable automatic retries for requests towards the application.
                       By default requests falling under: "connect-failure,refused-stream,unavailable,cancelled" will be retried.
+
+                      Retries require spec.routingProvider=Legacy. Gateway API serves HTTPRoute
+                      retries only on its experimental channel, which SKIP clusters do not install,
+                      so an Application that asks for both retries and Standard routing is rejected
+                      instead of losing its retry policy.
                     properties:
                       attempts:
                         description: |-
@@ -2285,6 +2290,11 @@ spec:
             - message: extraContainers ingressPort must differ from spec.port
               rule: '!has(self.extraContainers) || self.extraContainers.all(c, !has(c.ingressPort)
                 || c.ingressPort != self.port)'
+            - message: spec.istioSettings.retries is not supported with spec.routingProvider=Standard,
+                since Gateway API serves HTTPRoute retries only on its experimental
+                channel
+              rule: self.routingProvider != 'Standard' || !has(self.istioSettings)
+                || !has(self.istioSettings.retries)
           status:
             description: ApplicationStatus is a specialized status specific to the
               Application kind.

--- a/pkg/resourcegenerator/gatewayapi/application.go
+++ b/pkg/resourcegenerator/gatewayapi/application.go
@@ -3,6 +3,7 @@ package gatewayapi
 import (
 	"fmt"
 
+	"github.com/kartverket/skiperator/api/common/istiotypes"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -48,8 +49,21 @@ func generateForApplication(r reconciliation.Reconciliation) error {
 	}
 
 	backend := backendRule("default-app-route", application.Name, int32(application.Spec.Port), "/", false)
+	if err := applyRetries(&backend, applicationRetries(application), func(field string, value string) {
+		ctxLog.Warn("Ignoring unsupported Gateway API retry option", "kind", "Application", "namespace", application.Namespace, "name", application.Name, "field", field, "value", value)
+	}); err != nil {
+		return err
+	}
+
 	r.AddResource(newBackendRoute(application.Namespace, application.Name, "", listenerSetNames, hostnames, []gatewayapiv1.HTTPRouteRule{backend}))
 
 	ctxLog.Debug("Finished generating gateway api resources for application", "application", application.Name)
 	return nil
+}
+
+func applicationRetries(application *skiperatorv1alpha1.Application) *istiotypes.Retries {
+	if application.Spec.IstioSettings == nil {
+		return nil
+	}
+	return application.Spec.IstioSettings.Retries
 }

--- a/pkg/resourcegenerator/gatewayapi/gatewayapi.go
+++ b/pkg/resourcegenerator/gatewayapi/gatewayapi.go
@@ -1,11 +1,19 @@
 package gatewayapi
 
 import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/kartverket/skiperator/api/common"
+	"github.com/kartverket/skiperator/api/common/istiotypes"
 	"github.com/kartverket/skiperator/pkg/gwapi"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/resourceutils/generator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -13,6 +21,8 @@ const (
 	httpSectionName  gatewayapiv1.SectionName = "http"
 	httpsSectionName gatewayapiv1.SectionName = "https"
 )
+
+type unsupportedRetryOptionFunc func(field string, value string)
 
 var multiGenerator = generator.NewMulti()
 
@@ -219,4 +229,139 @@ func backendRule(name string, serviceName string, port int32, pathPrefix string,
 		}
 	}
 	return rule
+}
+
+// retriable5xxCodes expands Istio's "5xx" retry shorthand. Gateway API takes
+// explicit status codes, so the shorthand becomes the 5xx codes the Retries
+// enum permits (509 is not one of them).
+var retriable5xxCodes = []int{500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511}
+
+// retriable4xxCode is the only 4xx code Istio's "retriable-4xx" retries on.
+const retriable4xxCode = 409
+
+// applyRetries translates Istio retry settings onto a Gateway API rule.
+//
+// Unreachable while the Application CRD refuses retries together with
+// spec.routingProvider=Standard, because Gateway API serves rules[].retry only
+// on its experimental channel. Kept ready for the day retry graduates to the
+// standard channel: drop that CEL rule in api/v1alpha1/application_types.go and
+// this translation takes over. Timeouts are standard channel already.
+// Attempts and status codes become HTTPRouteRetry, and perTryTimeout becomes the
+// per-attempt Timeouts.BackendRequest. Settings that have no Gateway API
+// equivalent are reported through onUnsupportedRetryOption so users can see that
+// standard routing ignored part of their legacy config.
+func applyRetries(rule *gatewayapiv1.HTTPRouteRule, retries *istiotypes.Retries, onUnsupportedRetryOption unsupportedRetryOptionFunc) error {
+	if retries == nil {
+		return nil
+	}
+
+	attempts := 2
+	if retries.Attempts != nil {
+		attempts = int(*retries.Attempts)
+	}
+	rule.Retry = &gatewayapiv1.HTTPRouteRetry{Attempts: &attempts}
+
+	if retries.PerTryTimeout != nil {
+		timeout, err := gatewayAPIDuration(retries.PerTryTimeout.Duration)
+		if err != nil {
+			// Istio accepts durations GEP-2257 cannot express, e.g. sub-millisecond.
+			onUnsupportedRetryOption("perTryTimeout", retries.PerTryTimeout.Duration.String())
+		} else {
+			rule.Timeouts = &gatewayapiv1.HTTPRouteTimeouts{BackendRequest: &timeout}
+		}
+	}
+
+	if retries.RetryOnHttpResponseCodes == nil {
+		return nil
+	}
+
+	codes := make([]gatewayapiv1.HTTPRouteRetryStatusCode, 0, len(*retries.RetryOnHttpResponseCodes))
+	for _, code := range *retries.RetryOnHttpResponseCodes {
+		values, err := retryCodes(code, onUnsupportedRetryOption)
+		if err != nil {
+			return err
+		}
+		for _, value := range values {
+			codes = append(codes, gatewayapiv1.HTTPRouteRetryStatusCode(value))
+		}
+	}
+	// retry.codes is listType=set from Gateway API 1.6, so duplicates are
+	// rejected by the API server. Expanding "5xx" next to an explicit 503 is a
+	// realistic way to produce them.
+	slices.Sort(codes)
+	codes = slices.Compact(codes)
+	if len(codes) > 0 {
+		rule.Retry.Codes = codes
+	}
+	return nil
+}
+
+// retryCodes resolves one configured retry code to explicit status codes. The
+// "5xx" and "retriable-4xx" shorthands expand; anything else non-numeric is
+// reported as unsupported and dropped.
+func retryCodes(code intstr.IntOrString, onUnsupportedRetryOption unsupportedRetryOptionFunc) ([]int, error) {
+	if code.Type == intstr.Int {
+		value, err := validateRetryCode(code.IntValue())
+		if err != nil {
+			return nil, err
+		}
+		return []int{value}, nil
+	}
+	switch code.StrVal {
+	case "5xx":
+		return retriable5xxCodes, nil
+	case "retriable-4xx":
+		return []int{retriable4xxCode}, nil
+	}
+	value, err := strconv.Atoi(code.StrVal)
+	if err != nil {
+		onUnsupportedRetryOption("retryOnHttpResponseCodes", code.StrVal)
+		return nil, nil
+	}
+	value, err = validateRetryCode(value)
+	if err != nil {
+		return nil, err
+	}
+	return []int{value}, nil
+}
+
+func validateRetryCode(code int) (int, error) {
+	if code < 400 || code > 599 {
+		return 0, fmt.Errorf("gateway api retry status code must be between 400 and 599, got %d", code)
+	}
+	return code, nil
+}
+
+// gatewayAPIDuration renders d in the GEP-2257 duration subset Gateway API
+// accepts: whole milliseconds, largest unit first, no zero components, at most
+// five digits per component. Istio accepts durations outside that subset, so
+// callers must handle the error rather than assume every timeout translates.
+// See https://gateway-api.sigs.k8s.io/geps/gep-2257/.
+func gatewayAPIDuration(d time.Duration) (gatewayapiv1.Duration, error) {
+	if d <= 0 {
+		return "", fmt.Errorf("duration must be positive, got %s", d)
+	}
+	if d%time.Millisecond != 0 {
+		return "", fmt.Errorf("cannot express sub-millisecond precision of %s", d)
+	}
+
+	units := []struct {
+		suffix       string
+		milliseconds int64
+	}{{"h", 3600000}, {"m", 60000}, {"s", 1000}, {"ms", 1}}
+
+	remaining := d.Milliseconds()
+	var out strings.Builder
+	for _, unit := range units {
+		count := remaining / unit.milliseconds
+		if count == 0 {
+			continue
+		}
+		if count > 99999 {
+			return "", fmt.Errorf("duration %s is larger than GEP-2257 can express", d)
+		}
+		fmt.Fprintf(&out, "%d%s", count, unit.suffix)
+		remaining %= unit.milliseconds
+	}
+	return gatewayapiv1.Duration(out.String()), nil
 }

--- a/pkg/resourcegenerator/gatewayapi/gatewayapi_test.go
+++ b/pkg/resourcegenerator/gatewayapi/gatewayapi_test.go
@@ -3,7 +3,9 @@ package gatewayapi
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/kartverket/skiperator/api/common/istiotypes"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/internal/config"
 	"github.com/kartverket/skiperator/pkg/gwapi"
@@ -12,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -112,6 +115,86 @@ func TestApplicationLegacyRoutingSkipsGatewayAPI(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Empty(t, r.GetResources())
+}
+
+func TestApplyRetriesExpandsStringCodeShorthands(t *testing.T) {
+	codes := []intstr.IntOrString{
+		intstr.FromString("5xx"),
+		intstr.FromString("retriable-4xx"),
+		intstr.FromInt32(503),
+		intstr.FromString("teapot"),
+	}
+	attempts := int32(4)
+	unsupportedOptions := make(map[string][]string)
+	rule := gatewayapiv1.HTTPRouteRule{}
+
+	err := applyRetries(&rule, &istiotypes.Retries{
+		Attempts:                 &attempts,
+		RetryOnHttpResponseCodes: &codes,
+	}, func(field string, value string) {
+		unsupportedOptions[field] = append(unsupportedOptions[field], value)
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, rule.Retry)
+	require.Equal(t, 4, *rule.Retry.Attempts)
+	// Sorted and deduplicated: retry.codes is listType=set from Gateway API 1.6,
+	// and "5xx" already covers the explicit 503.
+	require.Equal(t, []gatewayapiv1.HTTPRouteRetryStatusCode{
+		409, 500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511,
+	}, rule.Retry.Codes)
+	require.Equal(t, []string{"teapot"}, unsupportedOptions["retryOnHttpResponseCodes"])
+}
+
+func TestApplyRetriesMapsPerTryTimeoutToBackendRequest(t *testing.T) {
+	timeout := metav1.Duration{Duration: 500 * time.Millisecond}
+	unsupportedOptions := make(map[string][]string)
+	rule := gatewayapiv1.HTTPRouteRule{}
+
+	err := applyRetries(&rule, &istiotypes.Retries{PerTryTimeout: &timeout}, func(field string, value string) {
+		unsupportedOptions[field] = append(unsupportedOptions[field], value)
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, rule.Timeouts)
+	require.Equal(t, gatewayapiv1.Duration("500ms"), *rule.Timeouts.BackendRequest)
+	require.Nil(t, rule.Retry.Backoff)
+	require.Empty(t, unsupportedOptions)
+}
+
+func TestApplyRetriesReportsInexpressiblePerTryTimeout(t *testing.T) {
+	timeout := metav1.Duration{Duration: 500 * time.Microsecond}
+	unsupportedOptions := make(map[string][]string)
+	rule := gatewayapiv1.HTTPRouteRule{}
+
+	err := applyRetries(&rule, &istiotypes.Retries{PerTryTimeout: &timeout}, func(field string, value string) {
+		unsupportedOptions[field] = append(unsupportedOptions[field], value)
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, rule.Timeouts)
+	require.Equal(t, []string{"500\u00b5s"}, unsupportedOptions["perTryTimeout"])
+}
+
+func TestGatewayAPIDuration(t *testing.T) {
+	for _, tc := range []struct {
+		duration time.Duration
+		expected gatewayapiv1.Duration
+	}{
+		{500 * time.Millisecond, "500ms"},
+		{time.Minute, "1m"},
+		{90 * time.Second, "1m30s"},
+		{time.Hour + 2*time.Minute + 3*time.Second + 4*time.Millisecond, "1h2m3s4ms"},
+	} {
+		got, err := gatewayAPIDuration(tc.duration)
+		require.NoError(t, err)
+		require.Equal(t, tc.expected, got)
+	}
+
+	for _, invalid := range []time.Duration{0, -time.Second, 100 * time.Microsecond} {
+		_, err := gatewayAPIDuration(invalid)
+		require.Error(t, err)
+	}
 }
 
 func skiperatorv1alpha1Bool(value bool) *bool {

--- a/tests/application/gateway-api/chainsaw-test.yaml
+++ b/tests/application/gateway-api/chainsaw-test.yaml
@@ -70,3 +70,18 @@ spec:
             file: namespace-not-in-mesh.yaml
         - assert:
             file: namespace-not-in-mesh-assert.yaml
+    - try:
+        # Gateway API serves HTTPRoute retries only on its experimental channel,
+        # which SKIP clusters do not install, so the Application CRD rejects
+        # retries together with Standard routing rather than letting the retry
+        # policy be dropped silently.
+        - apply:
+            file: unsupported-retries.yaml
+            expect:
+              - match:
+                  apiVersion: skiperator.kartverket.no/v1alpha1
+                  kind: Application
+                  metadata:
+                    name: unsupported-retries
+                check:
+                  ($error != null): true

--- a/tests/application/gateway-api/unsupported-retries.yaml
+++ b/tests/application/gateway-api/unsupported-retries.yaml
@@ -1,0 +1,15 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: unsupported-retries
+  namespace: gateway-api-application
+spec:
+  image: image
+  port: 8080
+  routingProvider: Standard
+  ingresses:
+    - unsupported-retries.example.com
+  istioSettings:
+    retries:
+      attempts: 3
+      retryOnHttpResponseCodes: [503]


### PR DESCRIPTION
Layer 6 of 9. Part of the stack that replaces #884. Builds on #937.

SKIP-1313

## What this does

Gateway API serves HTTPRoute retries only on its experimental channel, which SKIP
clusters do not install.

An Application that asked for both `spec.istioSettings.retries` and Standard routing
would have had its retry policy dropped without saying so. That is the kind of silent
difference that only shows up as a production incident. The CRD now rejects the
combination.

## The translation is written anyway

The gap is temporary, so the translation is implemented and tested:

- attempts and status codes become `HTTPRouteRetry`
- `perTryTimeout` becomes the per-attempt `Timeouts.BackendRequest`
- Istio's `5xx` and `retriable-4xx` shorthands expand to the explicit codes Gateway
  API takes

When retry graduates to the standard channel, deleting the CEL rule in
`api/v1alpha1/application_types.go` is enough to switch it on.

Settings with no Gateway API equivalent are reported through a callback and logged as
warnings rather than dropped quietly, so the same silent difference cannot come back
through a different door.