### PR TITLE
feat(routing): route Routing objects through Gateway API

### DIFF
--- a/api/v1alpha1/routing_types.go
+++ b/api/v1alpha1/routing_types.go
@@ -36,6 +36,7 @@ type Routing struct {
 }
 
 // +kubebuilder:object:generate=true
+// +kubebuilder:validation:XValidation:rule="self.hostname == oldSelf.hostname",message="spec.hostname is immutable"
 type RoutingSpec struct {
 	//+kubebuilder:validation:Required
 	Hostname string `json:"hostname"`
@@ -61,6 +62,8 @@ type Route struct {
 	//+kubebuilder:validation:Required
 	TargetApp string `json:"targetApp"`
 	//+kubebuilder:validation:Required
+	//+kubebuilder:validation:MinLength=1
+	//+kubebuilder:validation:Pattern=`^\/`
 	PathPrefix string `json:"pathPrefix"`
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:default:=false
@@ -87,17 +90,32 @@ func (in *Routing) UsesStandardRouting() bool {
 	return in.Spec.RoutingProvider == RoutingProviderStandard
 }
 
+func (in *Routing) Hostnames() (common.HostCollection, error) {
+	hosts := common.NewCollection()
+	if err := hosts.Add(in.Spec.Hostname); err != nil {
+		return hosts, err
+	}
+	return hosts, nil
+}
+
 // GetGatewayName returns the legacy Istio Gateway resource name.
 // This does not refer to a Kubernetes Gateway API Gateway.
 func (in *Routing) GetGatewayName() string {
 	return fmt.Sprintf("%s-routing-ingress", in.Name)
 }
 
+func (in *Routing) GetGatewayNames() ([]string, error) {
+	return []string{in.GetGatewayName()}, nil
+}
+
 func (in *Routing) GetVirtualServiceName() string {
 	return fmt.Sprintf("%s-routing-ingress", in.Name)
 }
 
-func (in *Routing) GetCertificateName() (string, error) {
+func (in *Routing) GetCertificateName(host *common.Host) (string, error) {
+	if host.UsesCustomCert() {
+		return *host.CustomCertificateSecret, nil
+	}
 	namePrefix := fmt.Sprintf("%s-%s", in.Namespace, in.Name)
 	// https://github.com/nais/naiserator/blob/faed273b68dff8541e1e2889fda5d017730f9796/pkg/resourcecreator/idporten/idporten.go#L82
 	// https://github.com/nais/naiserator/blob/faed273b68dff8541e1e2889fda5d017730f9796/pkg/resourcecreator/idporten/idporten.go#L170

--- a/config/crd/skiperator.kartverket.no_routings.yaml
+++ b/config/crd/skiperator.kartverket.no_routings.yaml
@@ -58,6 +58,8 @@ spec:
                 items:
                   properties:
                     pathPrefix:
+                      minLength: 1
+                      pattern: ^\/
                       type: string
                     port:
                       format: int32
@@ -85,6 +87,9 @@ spec:
             - hostname
             - routes
             type: object
+            x-kubernetes-validations:
+            - message: spec.hostname is immutable
+              rule: self.hostname == oldSelf.hostname
           status:
             description: |-
               SkiperatorStatus

--- a/internal/controllers/routing.go
+++ b/internal/controllers/routing.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
+	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/internal/controllers/common"
+	"github.com/kartverket/skiperator/pkg/gwapi"
 	"github.com/kartverket/skiperator/pkg/log"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/certificate"
+	gatewayapigenerator "github.com/kartverket/skiperator/pkg/resourcegenerator/gatewayapi"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/istio/gateway"
 	"github.com/kartverket/skiperator/pkg/resourcegenerator/istio/virtualservice"
 	networkpolicy "github.com/kartverket/skiperator/pkg/resourcegenerator/networkpolicy/dynamic"
@@ -23,16 +26,21 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // +kubebuilder:rbac:groups=skiperator.kartverket.no,resources=routings;routings/status,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=skiperator.kartverket.no,resources=applications;applications/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=gateways;virtualservices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=listenersets;httproutes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 
 type RoutingReconciler struct {
 	common.ReconcilerBase
@@ -44,11 +52,21 @@ func (r *RoutingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&istionetworkingv1.Gateway{}).
 		Owns(&networkingv1.NetworkPolicy{}).
 		Owns(&istionetworkingv1.VirtualService{}).
+		Owns(&gatewayapiv1.ListenerSet{}).
+		Owns(&gatewayapiv1.HTTPRoute{}).
 		Watches(&certmanagerv1.Certificate{}, handler.EnqueueRequestsFromMapFunc(r.skiperatorRoutingCertRequests)).
 		Watches(
 			&skiperatorv1alpha1.Application{},
 			handler.EnqueueRequestsFromMapFunc(r.skiperatorApplicationsChanges)).
-		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})).
+		WithEventFilter(predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			predicate.LabelChangedPredicate{},
+			// Finalizer-driven deletes arrive as metadata-only updates (deletion
+			// timestamp set, generation unchanged), so let those through too.
+			predicate.Funcs{UpdateFunc: func(e event.UpdateEvent) bool {
+				return !e.ObjectNew.GetDeletionTimestamp().IsZero()
+			}},
+		)).
 		Complete(r)
 }
 
@@ -82,6 +100,7 @@ func (r *RoutingReconciler) Reconcile(ctx context.Context, req reconcile.Request
 
 	if len(statusDiff) > 0 {
 		rLog.Info("Status has changed", "diff", statusDiff)
+		routing.GetStatus().SortConditions()
 		err = r.GetClient().Status().Update(ctx, routing)
 		return reconcile.Result{Requeue: true}, err
 	}
@@ -97,13 +116,40 @@ func (r *RoutingReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	rLog.Debug("Starting reconciliation loop", "routing", routing.Name)
 	r.SetProgressingState(ctx, routing, fmt.Sprintf("Routing %v has started reconciliation loop", routing.Name))
 
+	// Resolve mesh membership once and reuse it for both the Gateway API
+	// prerequisite check and the reconciliation, instead of looking the
+	// namespace up twice.
 	istioEnabled := r.IsIstioEnabledForNamespace(ctx, routing.Namespace)
 
+	// Gateway API uses shared cluster resources, so fail before generating
+	// resources if namespace setup or ownership checks are invalid.
+	if checkGatewayAPIPrerequisites(ctx, &r.ReconcilerBase, routing, istioEnabled, rLog) {
+		return common.DoNotRequeue()
+	}
+
 	reconciliationRouting := reconciliation.NewRoutingReconciliation(ctx, routing, rLog, istioEnabled, r.GetRestConfig(), targetAppPorts)
+	routingState, err := gwapi.EvaluateRoutingState(ctx, r.GetClient(), routing, routing.GetStatus())
+	if err != nil {
+		// A failed routing-state lookup must not be read as "legacy absent":
+		// requeue without generating resources so legacy routing is preserved.
+		rLog.Error(err, "failed to evaluate Gateway API routing state")
+		r.SetErrorState(ctx, routing, err, "failed to evaluate Gateway API routing state", "RoutingStateFailure")
+		return common.RequeueWithError(err)
+	}
+	reconciliationRouting.SetGenerateLegacyRouting(routingState.GenerateLegacyRouting)
+
+	// Prime migration status (start time + stall detection) before generating
+	// resources, so the migration clock advances and stalls are surfaced even if
+	// resource generation keeps failing. Persisted by the success or error path.
+	if routing.UsesStandardRouting() && !routingState.Readiness.Ready {
+		emitMigrationEvents(&r.ReconcilerBase, routing, gwapi.UpdateRoutingStatus(routing.GetStatus(), routing.GetGeneration(), routingState))
+	}
+
 	resourceGeneration := []reconciliationFunc{
 		networkpolicy.Generate,
 		virtualservice.Generate,
 		gateway.Generate,
+		gatewayapigenerator.Generate,
 		certificate.Generate,
 	}
 
@@ -141,7 +187,13 @@ func (r *RoutingReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		return common.RequeueWithError(err)
 	}
 
-	r.SetSyncedState(ctx, routing, "Routing has been reconciled")
+	// Ready/summary come from the shared routing-status assembler, the same path
+	// Application uses, so the two controllers cannot drift.
+	finalizeRoutingStatus(&r.ReconcilerBase, routing, routingState, "Routing has been reconciled")
+	r.UpdateStatus(ctx, routing)
+	if routing.UsesStandardRouting() && !routingState.Readiness.Ready {
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
 
 	return common.DoNotRequeue()
 }
@@ -169,7 +221,9 @@ func (r *RoutingReconciler) cleanUpWatchedResources(ctx context.Context, name ty
 	return processor.Process(reconciliation)
 }
 
-// TODO Do this with application too for dynamic port allocation?
+// reconcileSharedRoutingFinalizer adds/removes the shared-routing finalizer and,
+// on deletion, performs ref-counted cleanup of shared istio-gateways resources.
+// It returns handled=true when it owns the outcome of this reconcile pass.
 func (r *RoutingReconciler) setDefaultSpec(ctx context.Context, routing *skiperatorv1alpha1.Routing) (map[string]int32, error) {
 	targetAppPorts := make(map[string]int32)
 	for i := range routing.Spec.Routes {
@@ -245,8 +299,8 @@ func (r *RoutingReconciler) skiperatorRoutingCertRequests(_ context.Context, obj
 	if isSkiperatorRoutingOwned {
 		requests = append(requests, reconcile.Request{
 			NamespacedName: types.NamespacedName{
-				Namespace: certificate.Labels["application.skiperator.no/app-namespace"],
-				Name:      certificate.Labels["application.skiperator.no/app-name"],
+				Namespace: certificate.Labels["skiperator.kartverket.no/source-namespace"],
+				Name:      certificate.Labels["skiperator.kartverket.no/routing-name"],
 			},
 		})
 	}

--- a/pkg/gwapi/conflicts.go
+++ b/pkg/gwapi/conflicts.go
@@ -45,8 +45,85 @@ func validateApplicationConflicts(ctx context.Context, c client.Client, applicat
 	return nil
 }
 
+// validateRoutingConflicts enforces first-accepted-route-wins for shared
+// hostnames.
+//
+// This is what makes path-based product-team routing under one hostname
+// predictable. Skiperator refuses overlapping path prefixes only when the
+// existing HTTPRoute is already accepted by Gateway API. Redirect-only routes
+// are ignored because they do not claim a backend path.
+func validateRoutingConflicts(ctx context.Context, c client.Client, routing *skiperatorv1alpha1.Routing) error {
+	if !routing.UsesStandardRouting() {
+		return nil
+	}
+	hosts, err := routing.Hostnames()
+	if err != nil {
+		return err
+	}
+	host := hosts.AllHosts()[0]
+	if err := validateRoutingHostnameOwnership(ctx, c, routing, host.Hostname); err != nil {
+		return err
+	}
+	routes := &gatewayapiv1.HTTPRouteList{}
+	if err := c.List(ctx, routes); err != nil {
+		return fmt.Errorf("failed to list Gateway API HTTPRoutes: %w", err)
+	}
+	for _, existing := range routes.Items {
+		if !skiperatorManaged(existing.Labels) || sameRouting(existing.Labels, routing) || !routeAccepted(existing) || isRedirectRoute(existing) {
+			continue
+		}
+		if !routeHasHostname(existing, host.Hostname) {
+			continue
+		}
+		for _, existingRule := range existing.Spec.Rules {
+			for _, newRoute := range routing.Spec.Routes {
+				if routeRuleOverlaps(existingRule, newRoute.PathPrefix) {
+					return fmt.Errorf("path %q on hostname %q conflicts with accepted HTTPRoute %s/%s", newRoute.PathPrefix, host.Hostname, existing.Namespace, existing.Name)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// validateRoutingHostnameOwnership prevents a Routing from attaching to a
+// hostname already claimed by another object's ListenerSet.
+func validateRoutingHostnameOwnership(ctx context.Context, c client.Client, routing *skiperatorv1alpha1.Routing, hostname string) error {
+	listenerSets := &gatewayapiv1.ListenerSetList{}
+	if err := c.List(ctx, listenerSets); err != nil {
+		return fmt.Errorf("failed to list Gateway API ListenerSets: %w", err)
+	}
+	for _, listenerSet := range listenerSets.Items {
+		if !skiperatorManaged(listenerSet.Labels) || sameRouting(listenerSet.Labels, routing) {
+			continue
+		}
+		if listenerSet.Spec.ParentRef.Name != GatewayNameForHost(hostname) {
+			continue
+		}
+		for _, listener := range listenerSet.Spec.Listeners {
+			if !listenerCoversHostname(listener.Hostname, hostname) {
+				continue
+			}
+			if listenerSetAccepted(listenerSet) {
+				return fmt.Errorf("hostname %q already has an accepted ListenerSet %s/%s", hostname, listenerSet.Namespace, listenerSet.Name)
+			}
+			return fmt.Errorf("hostname %q already has a pending ListenerSet %s/%s", hostname, listenerSet.Namespace, listenerSet.Name)
+		}
+	}
+	return nil
+}
+
 func listenerSetAccepted(listenerSet gatewayapiv1.ListenerSet) bool {
 	return meta.IsStatusConditionTrue(listenerSet.Status.Conditions, string(gatewayapiv1.ListenerSetConditionAccepted))
+}
+
+func routeAccepted(route gatewayapiv1.HTTPRoute) bool {
+	for _, parent := range route.Status.Parents {
+		if meta.IsStatusConditionTrue(parent.Conditions, string(gatewayapiv1.RouteConditionAccepted)) {
+			return true
+		}
+	}
+	return false
 }
 
 func skiperatorManaged(labels map[string]string) bool {
@@ -59,6 +136,72 @@ func sameApplication(labels map[string]string, application *skiperatorv1alpha1.A
 		labels["application.skiperator.no/app-namespace"] == application.Namespace
 }
 
+func sameRouting(labels map[string]string, routing *skiperatorv1alpha1.Routing) bool {
+	return labels["skiperator.kartverket.no/controller"] == "routing" &&
+		labels["skiperator.kartverket.no/routing-name"] == routing.Name &&
+		labels["skiperator.kartverket.no/source-namespace"] == routing.Namespace
+}
+
+func isRedirectRoute(route gatewayapiv1.HTTPRoute) bool {
+	for _, rule := range route.Spec.Rules {
+		if len(rule.BackendRefs) > 0 {
+			return false
+		}
+		hasRedirect := false
+		for _, filter := range rule.Filters {
+			if filter.Type != gatewayapiv1.HTTPRouteFilterRequestRedirect {
+				return false
+			}
+			hasRedirect = true
+		}
+		if !hasRedirect {
+			return false
+		}
+	}
+	return len(route.Spec.Rules) > 0
+}
+
+func routeHasHostname(route gatewayapiv1.HTTPRoute, hostname string) bool {
+	hostname = strings.ToLower(hostname)
+	for _, h := range route.Spec.Hostnames {
+		if strings.ToLower(string(h)) == hostname {
+			return true
+		}
+	}
+	return len(route.Spec.Hostnames) == 0
+}
+
 func listenerCoversHostname(listenerHostname *gatewayapiv1.Hostname, hostname string) bool {
 	return listenerHostname == nil || strings.EqualFold(string(*listenerHostname), hostname)
+}
+
+// routeRuleOverlaps treats Gateway API PathPrefix matches as prefix trees.
+// "/api" conflicts with "/api/v1" because both can match the same request.
+// "/api" does not conflict with "/apiv2" because prefixes match path elements.
+// See sigs.k8s.io/gateway-api/apis/v1/httproute_types.go, PathMatchPathPrefix.
+func routeRuleOverlaps(rule gatewayapiv1.HTTPRouteRule, pathPrefix string) bool {
+	if len(rule.Matches) == 0 {
+		return true
+	}
+	for _, match := range rule.Matches {
+		if match.Path == nil || match.Path.Value == nil {
+			return pathPrefix == "/"
+		}
+		existing := *match.Path.Value
+		if pathPrefixesOverlap(existing, pathPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathPrefixesOverlap(a string, b string) bool {
+	return pathPrefixContains(a, b) || pathPrefixContains(b, a)
+}
+
+func pathPrefixContains(prefix string, path string) bool {
+	if !strings.HasPrefix(path, prefix) {
+		return false
+	}
+	return len(path) == len(prefix) || strings.HasSuffix(prefix, "/") || path[len(prefix)] == '/'
 }

--- a/pkg/gwapi/conflicts_test.go
+++ b/pkg/gwapi/conflicts_test.go
@@ -1,0 +1,45 @@
+package gwapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestRouteRuleOverlapsUsesPathElementBoundaries(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		existing  string
+		candidate string
+		want      bool
+	}{
+		{name: "same path", existing: "/api", candidate: "/api", want: true},
+		{name: "existing parent", existing: "/api", candidate: "/api/v1", want: true},
+		{name: "candidate parent", existing: "/api/v1", candidate: "/api", want: true},
+		{name: "sibling prefix", existing: "/api", candidate: "/apiv2", want: false},
+		{name: "sibling longer existing", existing: "/apiv2", candidate: "/api", want: false},
+		{name: "existing trailing slash", existing: "/api/", candidate: "/api/v1", want: true},
+		{name: "candidate trailing slash", existing: "/api/v1", candidate: "/api/", want: true},
+		{name: "root existing", existing: "/", candidate: "/api", want: true},
+		{name: "root candidate", existing: "/api", candidate: "/", want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, routeRuleOverlaps(routeRule(tt.existing), tt.candidate))
+		})
+	}
+}
+
+func routeRule(path string) gatewayapiv1.HTTPRouteRule {
+	pathType := gatewayapiv1.PathMatchPathPrefix
+	return gatewayapiv1.HTTPRouteRule{
+		Matches: []gatewayapiv1.HTTPRouteMatch{
+			{
+				Path: &gatewayapiv1.HTTPPathMatch{
+					Type:  &pathType,
+					Value: &path,
+				},
+			},
+		},
+	}
+}

--- a/pkg/gwapi/planner.go
+++ b/pkg/gwapi/planner.go
@@ -8,11 +8,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// routablePlanner centralizes the only per-kind type switch in this package.
-// Every per-type difference — Gateway API resource names, legacy resource refs,
-// and conflict scope — lives behind this interface, so the rest of gwapi stays
-// type-agnostic. Adding a new routable kind means adding one planner and one
-// case in plannerFor, touching nothing else.
+// routablePlanner centralizes the only Application-vs-Routing type switch in
+// this package. Every per-type difference — Gateway API resource names, legacy
+// resource refs, and conflict scope — lives behind this interface, so the rest
+// of gwapi stays type-agnostic. Adding a new routable kind means adding one
+// planner and one case in plannerFor, touching nothing else.
 type routablePlanner interface {
 	// Routable is satisfied by the embedded concrete object.
 	Routable
@@ -28,6 +28,8 @@ func plannerFor(routable Routable) (routablePlanner, error) {
 	switch obj := routable.(type) {
 	case *skiperatorv1alpha1.Application:
 		return applicationPlanner{obj}, nil
+	case *skiperatorv1alpha1.Routing:
+		return routingPlanner{obj}, nil
 	default:
 		return nil, fmt.Errorf("unsupported Gateway API routable type %T", routable)
 	}
@@ -53,4 +55,26 @@ func (p applicationPlanner) readinessPlan() (readinessPlan, error) {
 
 func (p applicationPlanner) validateConflicts(ctx context.Context, c client.Client) error {
 	return validateApplicationConflicts(ctx, c, p.Application)
+}
+
+type routingPlanner struct {
+	*skiperatorv1alpha1.Routing
+}
+
+func (p routingPlanner) readinessPlan() (readinessPlan, error) {
+	hosts, err := p.Hostnames()
+	if err != nil {
+		return readinessPlan{}, err
+	}
+	return buildReadinessPlan(planInput{
+		namespace:       p.Namespace,
+		routeBaseName:   RoutingResourcePrefix(p.Name),
+		redirectToHTTPS: p.GetRedirectToHTTPS(),
+		hosts:           hosts,
+		certificateName: p.GetCertificateName,
+	})
+}
+
+func (p routingPlanner) validateConflicts(ctx context.Context, c client.Client) error {
+	return validateRoutingConflicts(ctx, c, p.Routing)
 }

--- a/pkg/gwapi/readiness_test.go
+++ b/pkg/gwapi/readiness_test.go
@@ -1,0 +1,78 @@
+package gwapi
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	istionetworkingv1 "istio.io/client-go/pkg/apis/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type transientGetClient struct {
+	client.Client
+	failures int
+	gets     int
+}
+
+func (c *transientGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if c.gets < c.failures {
+		c.gets++
+		return errors.NewInternalError(fmt.Errorf("transient"))
+	}
+	c.gets++
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func TestLegacyRoutingExistsRetriesTransientGetFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, istionetworkingv1.AddToScheme(scheme))
+	routing := &skiperatorv1alpha1.Routing{ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"}}
+	virtualService := &istionetworkingv1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: "api-routing-ingress", Namespace: "team-a"}}
+	c := &transientGetClient{
+		Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(virtualService).Build(),
+		failures: 1,
+	}
+
+	exists, err := legacyRoutingExists(context.Background(), c, routing)
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.GreaterOrEqual(t, c.gets, 2)
+}
+
+func TestLegacyRoutingExistsReturnsErrorOnPersistentFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, istionetworkingv1.AddToScheme(scheme))
+	routing := &skiperatorv1alpha1.Routing{ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"}}
+	c := &transientGetClient{
+		Client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
+		failures: 1000,
+	}
+
+	// A persistent non-NotFound error must surface as an error, not be read as
+	// "legacy absent" (which would prune legacy routing mid-migration).
+	exists, err := legacyRoutingExists(context.Background(), c, routing)
+	require.Error(t, err)
+	assert.False(t, exists)
+}
+
+func TestLegacyRoutingExistsDoesNotRetryNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, istionetworkingv1.AddToScheme(scheme))
+	routing := &skiperatorv1alpha1.Routing{ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"}}
+	c := &transientGetClient{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+	}
+
+	exists, err := legacyRoutingExists(context.Background(), c, routing)
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.Equal(t, 2, c.gets)
+}

--- a/pkg/gwapi/routing_state_test.go
+++ b/pkg/gwapi/routing_state_test.go
@@ -192,6 +192,196 @@ func TestApplicationStandardRoutingCustomCertRequiresSecret(t *testing.T) {
 	assert.Contains(t, state.Readiness.Message, "Secret team-a/custom-tls")
 }
 
+func TestRoutingPathConflict(t *testing.T) {
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+	pathType := gatewayapiv1.PathMatchPathPrefix
+	path := "/v1"
+	route := &gatewayapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "accepted",
+			Namespace: "team-b",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by":        "skiperator",
+				"skiperator.kartverket.no/controller": "routing",
+			},
+		},
+		Spec: gatewayapiv1.HTTPRouteSpec{
+			Hostnames: []gatewayapiv1.Hostname{"API.example.COM"},
+			Rules: []gatewayapiv1.HTTPRouteRule{
+				{Matches: []gatewayapiv1.HTTPRouteMatch{{Path: &gatewayapiv1.HTTPPathMatch{Type: &pathType, Value: &path}}}},
+			},
+		},
+		Status: gatewayapiv1.HTTPRouteStatus{
+			RouteStatus: gatewayapiv1.RouteStatus{
+				Parents: []gatewayapiv1.RouteParentStatus{
+					{Conditions: []metav1.Condition{{Type: string(gatewayapiv1.RouteConditionAccepted), Status: metav1.ConditionTrue}}},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(route).Build()
+	routing := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "api.EXAMPLE.com",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+			Routes:          []skiperatorv1alpha1.Route{{TargetApp: "backend", PathPrefix: "/v1/users", Port: 8080}},
+		},
+	}
+
+	err := ValidateConflicts(context.Background(), c, routing)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts with accepted HTTPRoute")
+}
+
+func TestRoutingPathConflictWithMatchAllRule(t *testing.T) {
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+	route := &gatewayapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "accepted",
+			Namespace: "team-b",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by":        "skiperator",
+				"skiperator.kartverket.no/controller": "routing",
+			},
+		},
+		Spec: gatewayapiv1.HTTPRouteSpec{
+			Hostnames: []gatewayapiv1.Hostname{"api.example.com"},
+			Rules:     []gatewayapiv1.HTTPRouteRule{{}},
+		},
+		Status: gatewayapiv1.HTTPRouteStatus{
+			RouteStatus: gatewayapiv1.RouteStatus{
+				Parents: []gatewayapiv1.RouteParentStatus{
+					{Conditions: []metav1.Condition{{Type: string(gatewayapiv1.RouteConditionAccepted), Status: metav1.ConditionTrue}}},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(route).Build()
+	routing := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "api.example.com",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+			Routes:          []skiperatorv1alpha1.Route{{TargetApp: "backend", PathPrefix: "/v1", Port: 8080}},
+		},
+	}
+
+	err := ValidateConflicts(context.Background(), c, routing)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts with accepted HTTPRoute")
+}
+
+func TestRoutingConflictIgnoresRedirectRoute(t *testing.T) {
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+	pathType := gatewayapiv1.PathMatchPathPrefix
+	path := "/"
+	route := &gatewayapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "accepted-redirect",
+			Namespace: "team-b",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by":        "skiperator",
+				"skiperator.kartverket.no/controller": "routing",
+			},
+		},
+		Spec: gatewayapiv1.HTTPRouteSpec{
+			Hostnames: []gatewayapiv1.Hostname{"api.example.com"},
+			Rules: []gatewayapiv1.HTTPRouteRule{
+				{
+					Matches: []gatewayapiv1.HTTPRouteMatch{{Path: &gatewayapiv1.HTTPPathMatch{Type: &pathType, Value: &path}}},
+					Filters: []gatewayapiv1.HTTPRouteFilter{{Type: gatewayapiv1.HTTPRouteFilterRequestRedirect}},
+				},
+			},
+		},
+		Status: gatewayapiv1.HTTPRouteStatus{
+			RouteStatus: gatewayapiv1.RouteStatus{
+				Parents: []gatewayapiv1.RouteParentStatus{
+					{Conditions: []metav1.Condition{{Type: string(gatewayapiv1.RouteConditionAccepted), Status: metav1.ConditionTrue}}},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(route).Build()
+	routing := gatewayAPIRouting()
+
+	err := ValidateConflicts(context.Background(), c, routing)
+
+	require.NoError(t, err)
+}
+
+func TestRoutingStandardRoutingKeepsLegacyUntilReady(t *testing.T) {
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+	routing := gatewayAPIRouting()
+	legacy := &istionetworkingv1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: "api-routing-ingress", Namespace: "team-a"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(routing, legacy).Build()
+
+	state, err := EvaluateRoutingState(context.Background(), c, routing, routing.GetStatus())
+	require.NoError(t, err)
+
+	assert.True(t, state.GenerateLegacyRouting)
+	assert.False(t, state.Readiness.Ready)
+	assert.Contains(t, state.Readiness.Message, "Certificate")
+}
+
+func TestRoutingStandardRoutingPrunesLegacyWhenReady(t *testing.T) {
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+	routing := gatewayAPIRouting()
+	certificateName, err := routing.GetCertificateName(mustHost(t, "api.example.com"))
+	require.NoError(t, err)
+	objects := []client.Object{
+		routing,
+		&istionetworkingv1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: "api-routing-ingress", Namespace: "team-a"}},
+		readyGateway(IstioGatewayNamespace, ExternalGatewayName),
+		readyCertificate("team-a", certificateName),
+		tlsSecret("team-a", certificateName),
+		readyListenerSet("team-a", ListenerSetName(RoutingResourcePrefix("api"), "api.example.com")),
+		readyHTTPRoute("team-a", RoutingResourcePrefix("api")),
+		readyHTTPRoute("team-a", RedirectRouteName(RoutingResourcePrefix("api"))),
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+	state, err := EvaluateRoutingState(context.Background(), c, routing, routing.GetStatus())
+	require.NoError(t, err)
+
+	assert.False(t, state.GenerateLegacyRouting)
+	assert.True(t, state.Readiness.Ready)
+}
+
+func TestRoutingStandardRoutingGreenfieldSkipsLegacy(t *testing.T) {
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+	routing := gatewayAPIRouting()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(routing).Build()
+
+	state, err := EvaluateRoutingState(context.Background(), c, routing, routing.GetStatus())
+	require.NoError(t, err)
+
+	assert.False(t, state.GenerateLegacyRouting)
+	assert.False(t, state.Readiness.Ready)
+}
+
+func TestRoutingStandardRoutingCustomCertRequiresSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+	routing := gatewayAPIRouting()
+	routing.Spec.Hostname = "api.example.com+custom-tls"
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(routing).Build()
+
+	state, err := EvaluateRoutingState(context.Background(), c, routing, routing.GetStatus())
+	require.NoError(t, err)
+
+	assert.False(t, state.Readiness.Ready)
+	assert.Contains(t, state.Readiness.Message, "Secret team-a/custom-tls")
+}
+
 func TestListenerSetReadyWaitsForListenerStatus(t *testing.T) {
 	scheme := runtime.NewScheme()
 	resourceschemas.AddSchemas(scheme)
@@ -268,6 +458,19 @@ func gatewayAPIApplication() *skiperatorv1alpha1.Application {
 			Port:            8080,
 			Ingresses:       []string{"app.example.com"},
 			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+		},
+	}
+}
+
+func gatewayAPIRouting() *skiperatorv1alpha1.Routing {
+	return &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "api.example.com",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+			Routes: []skiperatorv1alpha1.Route{
+				{TargetApp: "backend", PathPrefix: "/", Port: 8080},
+			},
 		},
 	}
 }

--- a/pkg/reconciliation/routing.go
+++ b/pkg/reconciliation/routing.go
@@ -17,11 +17,12 @@ func NewRoutingReconciliation(ctx context.Context, routing *skiperatorv1alpha1.R
 	logger log.Logger, istioEnabled bool, restConfig *rest.Config, targetAppPorts map[string]int32) *RoutingReconciliation {
 	return &RoutingReconciliation{
 		baseReconciliation: baseReconciliation{
-			ctx:          ctx,
-			logger:       logger,
-			istioEnabled: istioEnabled,
-			restConfig:   restConfig,
-			skipObject:   routing,
+			ctx:                   ctx,
+			logger:                logger,
+			istioEnabled:          istioEnabled,
+			restConfig:            restConfig,
+			skipObject:            routing,
+			generateLegacyRouting: true,
 		},
 		targetAppPorts: targetAppPorts,
 	}

--- a/pkg/resourcegenerator/certificate/certificate_test.go
+++ b/pkg/resourcegenerator/certificate/certificate_test.go
@@ -1,0 +1,92 @@
+package certificate
+
+import (
+	"context"
+	"testing"
+
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/internal/config"
+	"github.com/kartverket/skiperator/pkg/log"
+	"github.com/kartverket/skiperator/pkg/mesh"
+	"github.com/kartverket/skiperator/pkg/reconciliation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestApplicationStandardRoutingGeneratesOnlyLocalCertWhenLegacyDisabled(t *testing.T) {
+	application := &skiperatorv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.ApplicationSpec{
+			Image:           "image",
+			Port:            8080,
+			Ingresses:       []string{"app.example.com"},
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+		},
+	}
+	r := reconciliation.NewApplicationReconciliation(context.Background(), application, log.NewLogger(), false, nil, nil, config.SkiperatorConfig{})
+	r.SetGenerateLegacyRouting(false)
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Len(t, r.GetResources(), 1)
+	assert.Equal(t, "team-a", r.GetResources()[0].GetNamespace())
+}
+
+func TestApplicationStandardRoutingKeepsLegacyCertWhenLegacyEnabled(t *testing.T) {
+	application := &skiperatorv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.ApplicationSpec{
+			Image:           "image",
+			Port:            8080,
+			Ingresses:       []string{"app.example.com"},
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+		},
+	}
+	r := reconciliation.NewApplicationReconciliation(context.Background(), application, log.NewLogger(), false, nil, nil, config.SkiperatorConfig{})
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Len(t, r.GetResources(), 2)
+	assert.Equal(t, mesh.GatewayNamespace, r.GetResources()[0].GetNamespace())
+	assert.Equal(t, "team-a", r.GetResources()[1].GetNamespace())
+}
+
+func TestApplicationLegacyRoutingGeneratesOnlyLegacyCert(t *testing.T) {
+	application := &skiperatorv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.ApplicationSpec{
+			Image:           "image",
+			Port:            8080,
+			Ingresses:       []string{"app.example.com"},
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderLegacy,
+		},
+	}
+	r := reconciliation.NewApplicationReconciliation(context.Background(), application, log.NewLogger(), false, nil, nil, config.SkiperatorConfig{})
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Len(t, r.GetResources(), 1)
+	assert.Equal(t, mesh.GatewayNamespace, r.GetResources()[0].GetNamespace())
+}
+
+func TestRoutingLegacyRoutingGeneratesOnlyLegacyCert(t *testing.T) {
+	routing := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "api.example.com",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderLegacy,
+			Routes:          []skiperatorv1alpha1.Route{{TargetApp: "backend", PathPrefix: "/", Port: 8080}},
+		},
+	}
+	r := reconciliation.NewRoutingReconciliation(context.Background(), routing, log.NewLogger(), false, nil, nil)
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Len(t, r.GetResources(), 1)
+	assert.Equal(t, mesh.GatewayNamespace, r.GetResources()[0].GetNamespace())
+}

--- a/pkg/resourcegenerator/certificate/routing.go
+++ b/pkg/resourcegenerator/certificate/routing.go
@@ -3,12 +3,9 @@ package certificate
 import (
 	"fmt"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {
@@ -38,23 +35,17 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 		return nil
 	}
 
-	certificateName, err := routing.GetCertificateName()
+	certificateName, err := routing.GetCertificateName(h)
 	if err != nil {
 		return err
 	}
 
-	certificate := certmanagerv1.Certificate{ObjectMeta: metav1.ObjectMeta{Namespace: mesh.GatewayNamespace, Name: certificateName}}
-
-	certificate.Spec = certmanagerv1.CertificateSpec{
-		IssuerRef: certmanagermetav1.IssuerReference{
-			Kind: "ClusterIssuer",
-			Name: "cluster-issuer", // Name defined in https://github.com/kartverket/certificate-management/blob/main/clusterissuer.tf
-		},
-		DNSNames:   []string{h.Hostname},
-		SecretName: certificateName,
+	if r.GenerateLegacyRouting() {
+		r.AddResource(newCertificate(mesh.GatewayNamespace, certificateName, h.Hostname))
 	}
-
-	r.AddResource(&certificate)
+	if routing.UsesStandardRouting() {
+		r.AddResource(newCertificate(routing.Namespace, certificateName, h.Hostname))
+	}
 
 	ctxLog.Debug("Finished generating certificates for routing", "routing", routing.Name)
 	return nil

--- a/pkg/resourcegenerator/gatewayapi/routing.go
+++ b/pkg/resourcegenerator/gatewayapi/routing.go
@@ -1,0 +1,53 @@
+package gatewayapi
+
+import (
+	"fmt"
+
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/gwapi"
+	"github.com/kartverket/skiperator/pkg/reconciliation"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func init() {
+	multiGenerator.Register(reconciliation.RoutingType, generateForRouting)
+}
+
+func generateForRouting(r reconciliation.Reconciliation) error {
+	ctxLog := r.GetLogger()
+	ctxLog.Debug("Attempting to generate gateway api resources for routing", "routing", r.GetSKIPObject().GetName())
+
+	routing, ok := r.GetSKIPObject().(*skiperatorv1alpha1.Routing)
+	if !ok {
+		return fmt.Errorf("failed to cast object to Routing")
+	}
+	if !routing.UsesStandardRouting() {
+		return nil
+	}
+
+	hosts, err := routing.Hostnames()
+	if err != nil {
+		return err
+	}
+	// Qualify the name so a standalone Routing and an equally named Application
+	// in the same namespace do not collide on Gateway API resource names.
+	routePrefix := gwapi.RoutingResourcePrefix(routing.Name)
+	listenerSetNames, hostnames, err := addListenerSets(r, routing.Namespace, routePrefix, hosts, routing.GetCertificateName)
+	if err != nil {
+		return err
+	}
+
+	if routing.GetRedirectToHTTPS() {
+		r.AddResource(newRedirectRoute(routing.Namespace, routePrefix, "", listenerSetNames, hostnames))
+	}
+
+	rules := make([]gatewayapiv1.HTTPRouteRule, 0, len(routing.Spec.Routes))
+	for _, route := range routing.Spec.Routes {
+		rules = append(rules, backendRule(route.TargetApp, route.TargetApp, route.Port, route.PathPrefix, route.RewriteUri))
+	}
+
+	r.AddResource(newBackendRoute(routing.Namespace, routePrefix, "", listenerSetNames, hostnames, rules))
+
+	ctxLog.Debug("Finished generating gateway api resources for routing", "routing", routing.Name)
+	return nil
+}

--- a/pkg/resourcegenerator/istio/gateway/gateway_test.go
+++ b/pkg/resourcegenerator/istio/gateway/gateway_test.go
@@ -1,0 +1,75 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/internal/config"
+	"github.com/kartverket/skiperator/pkg/log"
+	"github.com/kartverket/skiperator/pkg/reconciliation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	istionetworkingv1 "istio.io/client-go/pkg/apis/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestApplicationGatewaySkipsLegacyWhenDisabled(t *testing.T) {
+	application := &skiperatorv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.ApplicationSpec{
+			Image:           "image",
+			Port:            8080,
+			Ingresses:       []string{"app.example.com"},
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+		},
+	}
+	r := reconciliation.NewApplicationReconciliation(context.Background(), application, log.NewLogger(), false, nil, nil, config.SkiperatorConfig{})
+	r.SetGenerateLegacyRouting(false)
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Empty(t, r.GetResources())
+}
+
+func TestApplicationLegacyRoutingGeneratesGateway(t *testing.T) {
+	application := &skiperatorv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.ApplicationSpec{
+			Image:           "image",
+			Port:            8080,
+			Ingresses:       []string{"app.example.com"},
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderLegacy,
+		},
+	}
+	r := reconciliation.NewApplicationReconciliation(context.Background(), application, log.NewLogger(), false, nil, nil, config.SkiperatorConfig{})
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Len(t, r.GetResources(), 1)
+	gateway := r.GetResources()[0].(*istionetworkingv1.Gateway)
+	assert.Equal(t, "team-a", gateway.Namespace)
+	assert.Equal(t, application.GetGatewayName("app.example.com"), gateway.Name)
+}
+
+func TestRoutingLegacyRoutingGeneratesGateway(t *testing.T) {
+	routing := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "api.example.com",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderLegacy,
+			Routes:          []skiperatorv1alpha1.Route{{TargetApp: "backend", PathPrefix: "/", Port: 8080}},
+		},
+	}
+	r := reconciliation.NewRoutingReconciliation(context.Background(), routing, log.NewLogger(), false, nil, nil)
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Len(t, r.GetResources(), 1)
+	gateway := r.GetResources()[0].(*istionetworkingv1.Gateway)
+	assert.Equal(t, "team-a", gateway.Namespace)
+	assert.Equal(t, routing.GetGatewayName(), gateway.Name)
+}

--- a/pkg/resourcegenerator/istio/gateway/routing.go
+++ b/pkg/resourcegenerator/istio/gateway/routing.go
@@ -27,6 +27,9 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 	if !ok {
 		return fmt.Errorf("failed to cast object to routing")
 	}
+	if !r.GenerateLegacyRouting() {
+		return nil
+	}
 
 	h, err := routing.Spec.GetHost()
 	if err != nil {
@@ -39,7 +42,7 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 	if h.UsesCustomCert() {
 		determinedCredentialName = *h.CustomCertificateSecret
 	} else {
-		determinedCredentialName, err = routing.GetCertificateName()
+		determinedCredentialName, err = routing.GetCertificateName(h)
 		if err != nil {
 			return err
 		}

--- a/pkg/resourcegenerator/istio/virtualservice/routing.go
+++ b/pkg/resourcegenerator/istio/virtualservice/routing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/reconciliation"
 	networkingv1api "istio.io/api/networking/v1"
 	networkingv1 "istio.io/client-go/pkg/apis/networking/v1"
@@ -22,6 +23,9 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 	if !ok {
 		return fmt.Errorf("failed to cast object to Application")
 	}
+	if !r.GenerateLegacyRouting() {
+		return nil
+	}
 
 	virtualService := networkingv1.VirtualService{
 		ObjectMeta: v1.ObjectMeta{
@@ -36,7 +40,7 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 	}
 
 	virtualService.Spec = networkingv1api.VirtualService{
-		ExportTo: []string{".", "istio-system", "istio-gateways"},
+		ExportTo: []string{".", mesh.SystemNamespace, mesh.GatewayNamespace},
 		Gateways: []string{
 			routing.GetGatewayName(),
 		},

--- a/pkg/resourcegenerator/istio/virtualservice/virtual_service_test.go
+++ b/pkg/resourcegenerator/istio/virtualservice/virtual_service_test.go
@@ -1,0 +1,78 @@
+package virtualservice
+
+import (
+	"context"
+	"testing"
+
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	"github.com/kartverket/skiperator/internal/config"
+	"github.com/kartverket/skiperator/pkg/log"
+	"github.com/kartverket/skiperator/pkg/reconciliation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	istionetworkingv1 "istio.io/client-go/pkg/apis/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestApplicationVirtualServiceSkipsLegacyWhenDisabled(t *testing.T) {
+	application := &skiperatorv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.ApplicationSpec{
+			Image:           "image",
+			Port:            8080,
+			Ingresses:       []string{"app.example.com"},
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+		},
+	}
+	r := reconciliation.NewApplicationReconciliation(context.Background(), application, log.NewLogger(), false, nil, nil, config.SkiperatorConfig{})
+	r.SetGenerateLegacyRouting(false)
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Empty(t, r.GetResources())
+}
+
+func TestApplicationLegacyRoutingGeneratesVirtualService(t *testing.T) {
+	application := &skiperatorv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.ApplicationSpec{
+			Image:           "image",
+			Port:            8080,
+			Ingresses:       []string{"app.example.com"},
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderLegacy,
+			IstioSettings:   &skiperatorv1alpha1.IstioSettingsApplication{},
+		},
+	}
+	r := reconciliation.NewApplicationReconciliation(context.Background(), application, log.NewLogger(), false, nil, nil, config.SkiperatorConfig{})
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Len(t, r.GetResources(), 1)
+	virtualService := r.GetResources()[0].(*istionetworkingv1.VirtualService)
+	assert.Equal(t, "team-a", virtualService.Namespace)
+	assert.Equal(t, application.GetVirtualServiceName(), virtualService.Name)
+	assert.Equal(t, []string{"app.example.com"}, virtualService.Spec.Hosts)
+}
+
+func TestRoutingLegacyRoutingGeneratesVirtualService(t *testing.T) {
+	routing := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "api.example.com",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderLegacy,
+			Routes:          []skiperatorv1alpha1.Route{{TargetApp: "backend", PathPrefix: "/", Port: 8080}},
+		},
+	}
+	r := reconciliation.NewRoutingReconciliation(context.Background(), routing, log.NewLogger(), false, nil, nil)
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Len(t, r.GetResources(), 1)
+	virtualService := r.GetResources()[0].(*istionetworkingv1.VirtualService)
+	assert.Equal(t, "team-a", virtualService.Namespace)
+	assert.Equal(t, routing.GetVirtualServiceName(), virtualService.Name)
+	assert.Equal(t, []string{"api.example.com"}, virtualService.Spec.Hosts)
+}

--- a/tests/routing/gateway-api-migration/application.yaml
+++ b/tests/routing/gateway-api-migration/application.yaml
@@ -1,0 +1,7 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: migration-backend
+spec:
+  image: image
+  port: 8080

--- a/tests/routing/gateway-api-migration/chainsaw-test.yaml
+++ b/tests/routing/gateway-api-migration/chainsaw-test.yaml
@@ -1,0 +1,73 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: gateway-api-routing-migration
+spec:
+  skip: false
+  concurrent: true
+  skipDelete: false
+  namespace: gateway-api-routing-migration
+  steps:
+    - try:
+        - apply:
+            file: namespace.yaml
+        - create:
+            file: application.yaml
+        - create:
+            file: routing-legacy.yaml
+        - assert:
+            file: legacy-assert.yaml
+    - try:
+        - apply:
+            file: routing-standard.yaml
+        - assert:
+            file: standard-not-ready-assert.yaml
+        - error:
+            file: generated-cert-error.yaml
+    - try:
+        - apply:
+            file: ready-secret.yaml
+        - script:
+            content: |
+              kubectl -n gateway-api-routing-migration wait certificate migration-routing-tls --for=condition=Ready --timeout=120s
+        - script:
+            content: |
+              kubectl -n gateway-api-routing-migration wait listenerset migration-routing-routing-listener-6ec458aa1f12ad13 --for=condition=Accepted --timeout=120s
+              kubectl -n gateway-api-routing-migration wait listenerset migration-routing-routing-listener-6ec458aa1f12ad13 --for=condition=Programmed --timeout=120s
+
+              for i in $(seq 1 120); do
+                resolved=$(kubectl -n gateway-api-routing-migration get listenerset migration-routing-routing-listener-6ec458aa1f12ad13 -o jsonpath='{range .status.listeners[*].conditions[?(@.type=="ResolvedRefs")]}{.status}{"\n"}{end}' | grep -c '^True$' || true)
+                conflicted=$(kubectl -n gateway-api-routing-migration get listenerset migration-routing-routing-listener-6ec458aa1f12ad13 -o jsonpath='{range .status.listeners[*].conditions[?(@.type=="Conflicted")]}{.status}{"\n"}{end}' | grep -c '^True$' || true)
+                if [ "$resolved" -ge 2 ] && [ "$conflicted" -eq 0 ]; then
+                  break
+                fi
+                if [ "$i" -eq 120 ]; then
+                  kubectl -n gateway-api-routing-migration get listenerset migration-routing-routing-listener-6ec458aa1f12ad13 -o yaml
+                  exit 1
+                fi
+                sleep 1
+              done
+
+              wait_route_ready() {
+                name="$1"
+                for i in $(seq 1 120); do
+                  accepted=$(kubectl -n gateway-api-routing-migration get httproute "$name" -o jsonpath='{range .status.parents[*]}{range .conditions[?(@.type=="Accepted")]}{.status}{"\n"}{end}{end}' | grep -c '^True$' || true)
+                  resolved=$(kubectl -n gateway-api-routing-migration get httproute "$name" -o jsonpath='{range .status.parents[*]}{range .conditions[?(@.type=="ResolvedRefs")]}{.status}{"\n"}{end}{end}' | grep -c '^True$' || true)
+                  if [ "$accepted" -ge 1 ] && [ "$resolved" -ge 1 ]; then
+                    return 0
+                  fi
+                  sleep 1
+                done
+                kubectl -n gateway-api-routing-migration get httproute "$name" -o yaml
+                return 1
+              }
+
+              wait_route_ready migration-routing-routing
+              wait_route_ready migration-routing-routing-redirect
+        - script:
+            content: |
+              kubectl -n gateway-api-routing-migration label routings.skiperator.kartverket.no migration-routing gateway-api-migration-ready=true --overwrite
+        - assert:
+            file: standard-ready-assert.yaml
+        - error:
+            file: legacy-gone-error.yaml

--- a/tests/routing/gateway-api-migration/generated-cert-error.yaml
+++ b/tests/routing/gateway-api-migration/generated-cert-error.yaml
@@ -1,0 +1,5 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gateway-api-routing-migration-migration-routing-routin-1a126e27
+  namespace: gateway-api-routing-migration

--- a/tests/routing/gateway-api-migration/legacy-assert.yaml
+++ b/tests/routing/gateway-api-migration/legacy-assert.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: migration-routing-routing-ingress
+  namespace: gateway-api-routing-migration
+spec:
+  servers:
+    - hosts:
+        - migration-routing.example.com
+      port:
+        name: http
+        number: 80
+        protocol: HTTP
+    - hosts:
+        - migration-routing.example.com
+      port:
+        name: https
+        number: 443
+        protocol: HTTPS
+      tls:
+        credentialName: migration-routing-tls
+        mode: SIMPLE
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: migration-routing-routing-ingress
+  namespace: gateway-api-routing-migration
+spec:
+  hosts:
+    - migration-routing.example.com
+  gateways:
+    - migration-routing-routing-ingress
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: migration-routing
+  namespace: gateway-api-routing-migration
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled

--- a/tests/routing/gateway-api-migration/legacy-gone-error.yaml
+++ b/tests/routing/gateway-api-migration/legacy-gone-error.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: migration-routing-routing-ingress
+  namespace: gateway-api-routing-migration
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: migration-routing-routing-ingress
+  namespace: gateway-api-routing-migration

--- a/tests/routing/gateway-api-migration/namespace.yaml
+++ b/tests/routing/gateway-api-migration/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-api-routing-migration
+  labels:
+    istio.io/rev: asm-stable

--- a/tests/routing/gateway-api-migration/ready-secret.yaml
+++ b/tests/routing/gateway-api-migration/ready-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: migration-routing-tls
+  namespace: gateway-api-routing-migration
+spec:
+  dnsNames:
+    - migration-routing.example.com
+  issuerRef:
+    kind: ClusterIssuer
+    name: cluster-issuer
+  secretName: migration-routing-tls

--- a/tests/routing/gateway-api-migration/routing-legacy.yaml
+++ b/tests/routing/gateway-api-migration/routing-legacy.yaml
@@ -1,0 +1,11 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: migration-routing
+spec:
+  hostname: migration-routing.example.com+migration-routing-tls
+  redirectToHTTPS: true
+  routes:
+    - pathPrefix: /api
+      targetApp: migration-backend
+      port: 8080

--- a/tests/routing/gateway-api-migration/routing-standard.yaml
+++ b/tests/routing/gateway-api-migration/routing-standard.yaml
@@ -1,0 +1,12 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: migration-routing
+spec:
+  hostname: migration-routing.example.com+migration-routing-tls
+  routingProvider: Standard
+  redirectToHTTPS: true
+  routes:
+    - pathPrefix: /api
+      targetApp: migration-backend
+      port: 8080

--- a/tests/routing/gateway-api-migration/standard-not-ready-assert.yaml
+++ b/tests/routing/gateway-api-migration/standard-not-ready-assert.yaml
@@ -1,0 +1,91 @@
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: migration-routing-routing-ingress
+  namespace: gateway-api-routing-migration
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: migration-routing-routing-ingress
+  namespace: gateway-api-routing-migration
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: migration-routing-routing-listener-6ec458aa1f12ad13
+  namespace: gateway-api-routing-migration
+spec:
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: istio-external
+    namespace: istio-gateways
+  listeners:
+    - name: http
+      hostname: migration-routing.example.com
+      port: 80
+      protocol: HTTP
+    - name: https
+      hostname: migration-routing.example.com
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: migration-routing-tls
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: migration-routing-routing-redirect
+  namespace: gateway-api-routing-migration
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: migration-routing-routing-listener-6ec458aa1f12ad13
+      sectionName: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: migration-routing-routing
+  namespace: gateway-api-routing-migration
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: migration-routing-routing-listener-6ec458aa1f12ad13
+      sectionName: https
+  rules:
+    - name: migration-backend
+      matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: migration-backend
+          port: 8080
+          weight: 1
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: migration-routing
+  namespace: gateway-api-routing-migration
+status:
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: StandardRoutingNotReady
+    - type: LegacyRoutingActive
+      status: "True"
+      reason: LegacyRoutingActive
+    - type: StandardRoutingReady
+      status: "False"
+      reason: StandardRoutingNotReady

--- a/tests/routing/gateway-api-migration/standard-ready-assert.yaml
+++ b/tests/routing/gateway-api-migration/standard-ready-assert.yaml
@@ -1,0 +1,23 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: migration-routing
+  namespace: gateway-api-routing-migration
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
+    - type: LegacyRoutingActive
+      status: "False"
+      reason: LegacyRoutingInactive
+    - type: StandardRoutingReady
+      status: "True"
+      reason: StandardRoutingReady
+  subresources:
+    HTTPRoute[migration-routing-routing-redirect]:
+      status: Synced
+    HTTPRoute[migration-routing-routing]:
+      status: Synced
+    ListenerSet[migration-routing-routing-listener-6ec458aa1f12ad13]:
+      status: Synced

--- a/tests/routing/gateway-api/application.yaml
+++ b/tests/routing/gateway-api/application.yaml
@@ -1,0 +1,15 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: app-1
+spec:
+  image: image
+  port: 8081
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: app-2
+spec:
+  image: image
+  port: 9000

--- a/tests/routing/gateway-api/chainsaw-test.yaml
+++ b/tests/routing/gateway-api/chainsaw-test.yaml
@@ -1,0 +1,96 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: gateway-api-routing
+spec:
+  skip: false
+  concurrent: true
+  skipDelete: false
+  namespace: gateway-api-routing
+  steps:
+    - try:
+        - apply:
+            file: namespace.yaml
+        - apply:
+            file: application.yaml
+        - apply:
+            file: routing.yaml
+        - script:
+            content: |
+              kubectl -n gateway-api-routing wait certificate gateway-api-routing-api-routing-ingress-af0fa765 --for=condition=Ready --timeout=120s
+              kubectl -n gateway-api-routing wait listenerset api-routing-listener-f28e273ed55ce9a6 --for=condition=Accepted --timeout=120s
+              kubectl -n gateway-api-routing wait listenerset api-routing-listener-f28e273ed55ce9a6 --for=condition=Programmed --timeout=120s
+
+              for i in $(seq 1 120); do
+                resolved=$(kubectl -n gateway-api-routing get listenerset api-routing-listener-f28e273ed55ce9a6 -o jsonpath='{range .status.listeners[*].conditions[?(@.type=="ResolvedRefs")]}{.status}{"\n"}{end}' | grep -c '^True$' || true)
+                conflicted=$(kubectl -n gateway-api-routing get listenerset api-routing-listener-f28e273ed55ce9a6 -o jsonpath='{range .status.listeners[*].conditions[?(@.type=="Conflicted")]}{.status}{"\n"}{end}' | grep -c '^True$' || true)
+                if [ "$resolved" -ge 2 ] && [ "$conflicted" -eq 0 ]; then
+                  break
+                fi
+                if [ "$i" -eq 120 ]; then
+                  kubectl -n gateway-api-routing get listenerset api-routing-listener-f28e273ed55ce9a6 -o yaml
+                  exit 1
+                fi
+                sleep 1
+              done
+
+              wait_route_ready() {
+                name="$1"
+                for i in $(seq 1 120); do
+                  accepted=$(kubectl -n gateway-api-routing get httproute "$name" -o jsonpath='{range .status.parents[*]}{range .conditions[?(@.type=="Accepted")]}{.status}{"\n"}{end}{end}' | grep -c '^True$' || true)
+                  resolved=$(kubectl -n gateway-api-routing get httproute "$name" -o jsonpath='{range .status.parents[*]}{range .conditions[?(@.type=="ResolvedRefs")]}{.status}{"\n"}{end}{end}' | grep -c '^True$' || true)
+                  if [ "$accepted" -ge 1 ] && [ "$resolved" -ge 1 ]; then
+                    return 0
+                  fi
+                  sleep 1
+                done
+                kubectl -n gateway-api-routing get httproute "$name" -o yaml
+                return 1
+              }
+
+              wait_route_ready api-routing
+              wait_route_ready api-routing-redirect
+        - script:
+            content: |
+              kubectl -n gateway-api-routing label routings.skiperator.kartverket.no api gateway-api-ready=true --overwrite
+        - assert:
+            file: routing-assert.yaml
+    - try:
+        - apply:
+            file: shared-hostname-routing.yaml
+        - script:
+            content: |
+              kubectl -n gateway-api-routing wait certificate gateway-api-routing-shared-api-routing-ingress-ecd89812 --for=condition=Ready --timeout=120s
+              kubectl -n gateway-api-routing wait listenerset shared-api-routing-listener-37798cf1f25da647 --for=condition=Accepted --timeout=120s
+              kubectl -n gateway-api-routing wait listenerset shared-api-routing-listener-37798cf1f25da647 --for=condition=Programmed --timeout=120s
+
+              for i in $(seq 1 120); do
+                resolved=$(kubectl -n gateway-api-routing get listenerset shared-api-routing-listener-37798cf1f25da647 -o jsonpath='{range .status.listeners[*].conditions[?(@.type=="ResolvedRefs")]}{.status}{"\n"}{end}' | grep -c '^True$' || true)
+                conflicted=$(kubectl -n gateway-api-routing get listenerset shared-api-routing-listener-37798cf1f25da647 -o jsonpath='{range .status.listeners[*].conditions[?(@.type=="Conflicted")]}{.status}{"\n"}{end}' | grep -c '^True$' || true)
+                if [ "$resolved" -ge 2 ] && [ "$conflicted" -eq 0 ]; then
+                  break
+                fi
+                if [ "$i" -eq 120 ]; then
+                  kubectl -n gateway-api-routing get listenerset shared-api-routing-listener-37798cf1f25da647 -o yaml
+                  exit 1
+                fi
+                sleep 1
+              done
+
+              for i in $(seq 1 120); do
+                accepted=$(kubectl -n gateway-api-routing get httproute shared-api-routing -o jsonpath='{range .status.parents[*]}{range .conditions[?(@.type=="Accepted")]}{.status}{"\n"}{end}{end}' | grep -c '^True$' || true)
+                resolved=$(kubectl -n gateway-api-routing get httproute shared-api-routing -o jsonpath='{range .status.parents[*]}{range .conditions[?(@.type=="ResolvedRefs")]}{.status}{"\n"}{end}{end}' | grep -c '^True$' || true)
+                if [ "$accepted" -ge 1 ] && [ "$resolved" -ge 1 ]; then
+                  break
+                fi
+                if [ "$i" -eq 120 ]; then
+                  kubectl -n gateway-api-routing get httproute shared-api-routing -o yaml
+                  exit 1
+                fi
+                sleep 1
+              done
+        - script:
+            content: |
+              kubectl -n gateway-api-routing label routings.skiperator.kartverket.no shared-api gateway-api-ready=true --overwrite
+        - assert:
+            file: shared-hostname-routing-assert.yaml

--- a/tests/routing/gateway-api/namespace.yaml
+++ b/tests/routing/gateway-api/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-api-routing
+  labels:
+    istio.io/rev: asm-stable

--- a/tests/routing/gateway-api/routing-assert.yaml
+++ b/tests/routing/gateway-api/routing-assert.yaml
@@ -1,0 +1,140 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gateway-api-routing-api-routing-ingress-af0fa765
+  namespace: gateway-api-routing
+spec:
+  dnsNames:
+    - api.example.com
+  issuerRef:
+    kind: ClusterIssuer
+    name: cluster-issuer
+  secretName: gateway-api-routing-api-routing-ingress-af0fa765
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: api-routing-listener-f28e273ed55ce9a6
+  namespace: gateway-api-routing
+spec:
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: istio-external
+    namespace: istio-gateways
+  listeners:
+    - name: http
+      hostname: api.example.com
+      port: 80
+      protocol: HTTP
+    - name: https
+      hostname: api.example.com
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: gateway-api-routing-api-routing-ingress-af0fa765
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-routing-redirect
+  namespace: gateway-api-routing
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: api-routing-listener-f28e273ed55ce9a6
+      sectionName: http
+  hostnames:
+    - api.example.com
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 308
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-routing
+  namespace: gateway-api-routing
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: api-routing-listener-f28e273ed55ce9a6
+      sectionName: https
+  hostnames:
+    - api.example.com
+  rules:
+    - name: app-1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /app1
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: app-1
+          port: 8081
+          weight: 1
+    - name: app-2
+      matches:
+        - path:
+            type: PathPrefix
+            value: /app2
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: app-2
+          port: 9000
+          weight: 1
+
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: api
+  namespace: gateway-api-routing
+spec:
+  routingProvider: Standard
+status:
+  summary:
+    status: Synced
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Reconciled
+    - type: LegacyRoutingActive
+      status: "False"
+      reason: LegacyRoutingInactive
+    - type: StandardRoutingReady
+      status: "True"
+      reason: StandardRoutingReady
+  subresources:
+    Certificate[gateway-api-routing-api-routing-ingress-af0fa765]:
+      status: Synced
+    HTTPRoute[api-routing-redirect]:
+      status: Synced
+    HTTPRoute[api-routing]:
+      status: Synced
+    ListenerSet[api-routing-listener-f28e273ed55ce9a6]:
+      status: Synced

--- a/tests/routing/gateway-api/routing.yaml
+++ b/tests/routing/gateway-api/routing.yaml
@@ -1,0 +1,16 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: api
+spec:
+  hostname: api.example.com
+  routingProvider: Standard
+  redirectToHTTPS: true
+  routes:
+    - pathPrefix: /app1
+      targetApp: app-1
+      port: 8081
+    - pathPrefix: /app2
+      targetApp: app-2
+      port: 9000
+      rewriteUri: true

--- a/tests/routing/gateway-api/shared-hostname-routing-assert.yaml
+++ b/tests/routing/gateway-api/shared-hostname-routing-assert.yaml
@@ -1,0 +1,67 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gateway-api-routing-shared-api-routing-ingress-ecd89812
+  namespace: gateway-api-routing
+spec:
+  dnsNames:
+    - api.kartverket.no
+  issuerRef:
+    kind: ClusterIssuer
+    name: cluster-issuer
+  secretName: gateway-api-routing-shared-api-routing-ingress-ecd89812
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: shared-api-routing-listener-37798cf1f25da647
+  namespace: gateway-api-routing
+spec:
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: istio-external
+    namespace: istio-gateways
+  listeners:
+    - name: http
+      hostname: api.kartverket.no
+      port: 80
+      protocol: HTTP
+    - name: https
+      hostname: api.kartverket.no
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: gateway-api-routing-shared-api-routing-ingress-ecd89812
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: shared-api-routing
+  namespace: gateway-api-routing
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: shared-api-routing-listener-37798cf1f25da647
+      sectionName: https
+  hostnames:
+    - api.kartverket.no
+  rules:
+    - name: app-1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /team-a
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: app-1
+          port: 8081
+          weight: 1

--- a/tests/routing/gateway-api/shared-hostname-routing.yaml
+++ b/tests/routing/gateway-api/shared-hostname-routing.yaml
@@ -1,0 +1,12 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: shared-api
+spec:
+  hostname: api.kartverket.no
+  routingProvider: Standard
+  redirectToHTTPS: false
+  routes:
+    - pathPrefix: /team-a
+      targetApp: app-1
+      port: 8081

--- a/tests/routing/routes/chainsaw-test.yaml
+++ b/tests/routing/routes/chainsaw-test.yaml
@@ -33,6 +33,11 @@ spec:
         - assert:
             file: patch-routing-change-path-assert.yaml
     - try:
+        - delete:
+            ref:
+              apiVersion: skiperator.kartverket.no/v1alpha1
+              kind: Routing
+              name: app-paths
         - apply:
             file: patch-routing-change-hostname.yaml
         - assert:


### PR DESCRIPTION
Layer 7 of 9. Part of the stack that replaces #884. Builds on #938.

SKIP-1313

## What this does

A Routing with `spec.routingProvider: Standard` now generates a `ListenerSet`,
`HTTPRoute`s and a `Certificate` in its own namespace, on the same
keep-legacy-until-ready migration path Application uses. Both controllers share
`finalizeRoutingStatus`, so their status handling cannot drift apart.

Adding Routing needed one planner and one case in `plannerFor`, which is what the
Plan/Observe split in layer #936 was for.

## Naming

Gateway API resource names are qualified with a `-routing` prefix. A Routing and an
Application can carry the same name in one namespace, and without the prefix they
would collide on ListenerSet and HTTPRoute names. The prefix mirrors the existing
`<name>-routing-ingress` convention for legacy resources.

## Conflicts are path based, not hostname based

Two Routing objects sharing one hostname with different path prefixes is a
legitimate setup, so Routing cannot use the hostname rule Application uses.

Overlapping prefixes are refused only when the existing HTTPRoute is already
accepted by Gateway API, so the first accepted route wins instead of two objects
flapping. Overlap is judged on path elements: `/api` conflicts with `/api/v1` but not
with `/apiv2`, matching how Gateway API evaluates `PathPrefix`. Redirect-only routes
claim no backend path and are ignored.

## Two new input rules

- `spec.hostname` is immutable. The hostname keys every generated resource name, so
  editing it would leave the old ListenerSet and Certificate behind with nothing to
  prune them.
- Route path prefixes must be non-empty and start with `/`, which Gateway API
  requires of a `PathPrefix` match anyway.

The `tests/routing/routes` suite deletes and recreates the Routing where it used to
patch the hostname.