### PR TITLE
feat(routing): share one hostname across namespaces

### DIFF
--- a/api-docs.md
+++ b/api-docs.md
@@ -4376,6 +4376,17 @@ Status
         <td>true</td>
       </tr>
       <tr>
+        <td><b>ownership</b></td>
+        <td>enum</td>
+        <td>
+          Ownership controls whether this Routing owns the hostname exclusively or<br/>contributes paths to a shared hostname.<br/>
+          <br/>
+            <i>Enum</i>: Standalone, Shared<br/>
+            <i>Default</i>: `Standalone`<br/>
+        </td>
+        <td>false</td>
+      </tr>
+      <tr>
         <td><b>redirectToHTTPS</b></td>
         <td>boolean</td>
         <td>

--- a/api/common/status_types.go
+++ b/api/common/status_types.go
@@ -45,6 +45,7 @@ const (
 	ReadyConditionType                = "Ready"
 	StandardRoutingReadyConditionType = "StandardRoutingReady"
 	LegacyRoutingActiveConditionType  = "LegacyRoutingActive"
+	SharedRoutingResourcesType        = "SharedRoutingResources"
 
 	// MigrationStalledReason is the condition reason written when a Gateway API
 	// migration has kept legacy routing active past the deadline. Shared so the
@@ -68,6 +69,7 @@ var conditionOrder = map[string]int{
 	"ExternalRulesValid":              5,
 	LegacyRoutingActiveConditionType:  6,
 	StandardRoutingReadyConditionType: 7,
+	SharedRoutingResourcesType:        8,
 }
 
 // SortConditions orders Conditions canonically (see conditionOrder), so the
@@ -155,6 +157,12 @@ func (s *SkiperatorStatus) SetStandardRoutingReadyCondition(status metav1.Condit
 
 func (s *SkiperatorStatus) SetLegacyRoutingActiveCondition(status metav1.ConditionStatus, observedGeneration int64, reason string, message string) {
 	s.setCondition(LegacyRoutingActiveConditionType, status, observedGeneration, reason, message)
+}
+
+// SetSharedRoutingResourcesCondition records whether a Routing depends on
+// shared Gateway API listener, redirect, and certificate resources.
+func (s *SkiperatorStatus) SetSharedRoutingResourcesCondition(status metav1.ConditionStatus, observedGeneration int64, reason string, message string) {
+	s.setCondition(SharedRoutingResourcesType, status, observedGeneration, reason, message)
 }
 
 func (s *SkiperatorStatus) AddSubResourceStatus(object client.Object, message string, status StatusNames) {

--- a/api/common/status_types_test.go
+++ b/api/common/status_types_test.go
@@ -49,3 +49,17 @@ func TestSetLegacyRoutingActiveCondition(t *testing.T) {
 		assert.Equal(t, "legacy routing is active", requirement.Message)
 	}
 }
+
+func TestSetSharedRoutingResourcesCondition(t *testing.T) {
+	status := &SkiperatorStatus{}
+
+	status.SetSharedRoutingResourcesCondition(metav1.ConditionTrue, 6, "SharedRoutingResourcesActive", "shared routing resources are active")
+
+	requirement := meta.FindStatusCondition(status.Conditions, SharedRoutingResourcesType)
+	if assert.NotNil(t, requirement) {
+		assert.Equal(t, metav1.ConditionTrue, requirement.Status)
+		assert.Equal(t, int64(6), requirement.ObservedGeneration)
+		assert.Equal(t, "SharedRoutingResourcesActive", requirement.Reason)
+		assert.Equal(t, "shared routing resources are active", requirement.Message)
+	}
+}

--- a/api/v1alpha1/routing_types.go
+++ b/api/v1alpha1/routing_types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kartverket/skiperator/api/common"
+	"github.com/kartverket/skiperator/pkg/util"
 	"github.com/nais/liberator/pkg/namegen"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -36,6 +37,7 @@ type Routing struct {
 }
 
 // +kubebuilder:object:generate=true
+// +kubebuilder:validation:XValidation:rule="!has(self.ownership) || self.ownership != 'Shared' || self.routingProvider == 'Standard'",message="spec.ownership=Shared requires spec.routingProvider=Standard"
 // +kubebuilder:validation:XValidation:rule="self.hostname == oldSelf.hostname",message="spec.hostname is immutable"
 type RoutingSpec struct {
 	//+kubebuilder:validation:Required
@@ -49,6 +51,14 @@ type RoutingSpec struct {
 	//+kubebuilder:default=Legacy
 	RoutingProvider RoutingProvider `json:"routingProvider,omitempty"`
 
+	// Ownership controls whether this Routing owns the hostname exclusively or
+	// contributes paths to a shared hostname.
+	//
+	//+kubebuilder:validation:Enum=Standalone;Shared
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:default=Standalone
+	Ownership RoutingOwnership `json:"ownership,omitempty"`
+
 	//+kubebuilder:validation:Required
 	Routes []Route `json:"routes"`
 
@@ -56,6 +66,17 @@ type RoutingSpec struct {
 	//+kubebuilder:default:=true
 	RedirectToHTTPS *bool `json:"redirectToHTTPS,omitempty"`
 }
+
+// RoutingOwnership controls whether one Routing owns a hostname or shares it
+// with other Routing objects using non-overlapping path prefixes.
+type RoutingOwnership string
+
+const (
+	// RoutingOwnershipStandalone means this Routing owns the whole hostname.
+	RoutingOwnershipStandalone RoutingOwnership = "Standalone"
+	// RoutingOwnershipShared means this Routing contributes paths to shared hostname resources.
+	RoutingOwnershipShared RoutingOwnership = "Shared"
+)
 
 // +kubebuilder:object:generate=true
 type Route struct {
@@ -90,6 +111,12 @@ func (in *Routing) UsesStandardRouting() bool {
 	return in.Spec.RoutingProvider == RoutingProviderStandard
 }
 
+// UsesSharedOwnership returns true when Gateway API resources that terminate
+// TLS and expose listeners should live in the shared istio-gateways namespace.
+func (in *Routing) UsesSharedOwnership() bool {
+	return in.Spec.Ownership == RoutingOwnershipShared
+}
+
 func (in *Routing) Hostnames() (common.HostCollection, error) {
 	hosts := common.NewCollection()
 	if err := hosts.Add(in.Spec.Hostname); err != nil {
@@ -115,6 +142,13 @@ func (in *Routing) GetVirtualServiceName() string {
 func (in *Routing) GetCertificateName(host *common.Host) (string, error) {
 	if host.UsesCustomCert() {
 		return *host.CustomCertificateSecret, nil
+	}
+	if in.UsesSharedOwnership() {
+		// Shared ownership: key the certificate on the hostname (not the
+		// contributing Routing's identity) so every contributor converges on a
+		// single shared certificate in istio-gateways, instead of each writing a
+		// different cert ref into the shared ListenerSet.
+		return namegen.ShortName(fmt.Sprintf("shared-%x-routing-ingress", util.GenerateHashFromName(host.Hostname)), validation.DNS1035LabelMaxLength)
 	}
 	namePrefix := fmt.Sprintf("%s-%s", in.Namespace, in.Name)
 	// https://github.com/nais/naiserator/blob/faed273b68dff8541e1e2889fda5d017730f9796/pkg/resourcecreator/idporten/idporten.go#L82

--- a/config/crd/skiperator.kartverket.no_routings.yaml
+++ b/config/crd/skiperator.kartverket.no_routings.yaml
@@ -51,6 +51,15 @@ spec:
             properties:
               hostname:
                 type: string
+              ownership:
+                default: Standalone
+                description: |-
+                  Ownership controls whether this Routing owns the hostname exclusively or
+                  contributes paths to a shared hostname.
+                enum:
+                - Standalone
+                - Shared
+                type: string
               redirectToHTTPS:
                 default: true
                 type: boolean
@@ -88,6 +97,9 @@ spec:
             - routes
             type: object
             x-kubernetes-validations:
+            - message: spec.ownership=Shared requires spec.routingProvider=Standard
+              rule: '!has(self.ownership) || self.ownership != ''Shared'' || self.routingProvider
+                == ''Standard'''
             - message: spec.hostname is immutable
               rule: self.hostname == oldSelf.hostname
           status:

--- a/internal/controllers/common/util.go
+++ b/internal/controllers/common/util.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/kartverket/skiperator/api/common"
 	"github.com/kartverket/skiperator/api/common/podtypes"
+	"github.com/kartverket/skiperator/pkg/mesh"
 	"github.com/kartverket/skiperator/pkg/metrics/usage"
 	"github.com/r3labs/diff/v3"
 	corev1 "k8s.io/api/core/v1"
@@ -141,9 +142,27 @@ func SetReadyReconciled(obj common.SKIPObject, message string) {
 	obj.GetStatus().SetReadyCondition(metav1.ConditionTrue, obj.GetGeneration(), "Reconciled", message)
 }
 
+// SetSharedRoutingResourcesActive marks that the object contributes to shared
+// Gateway API resources, which live outside its own namespace.
+func SetSharedRoutingResourcesActive(obj common.SKIPObject) {
+	obj.GetStatus().SetSharedRoutingResourcesCondition(
+		metav1.ConditionTrue,
+		obj.GetGeneration(),
+		"SharedRoutingResourcesActive",
+		fmt.Sprintf("Routing uses shared Gateway API resources in %s", mesh.GatewayNamespace),
+	)
+}
+
+// ClearSharedRoutingResourcesCondition drops the condition, so a standalone
+// object does not carry one.
+func ClearSharedRoutingResourcesCondition(obj common.SKIPObject) {
+	meta.RemoveStatusCondition(&obj.GetStatus().Conditions, common.SharedRoutingResourcesType)
+}
+
 func ClearGatewayAPIConditions(obj common.SKIPObject) {
 	meta.RemoveStatusCondition(&obj.GetStatus().Conditions, common.StandardRoutingReadyConditionType)
 	meta.RemoveStatusCondition(&obj.GetStatus().Conditions, common.LegacyRoutingActiveConditionType)
+	meta.RemoveStatusCondition(&obj.GetStatus().Conditions, common.SharedRoutingResourcesType)
 	// Drop the migration clock too, so switching back to legacy does not leave
 	// a stale start time that mis-seeds a future migration as already stalled.
 	obj.GetStatus().MigrationStartedAt = nil

--- a/internal/controllers/common/util_test.go
+++ b/internal/controllers/common/util_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 	"time"
 
+	commontypes "github.com/kartverket/skiperator/api/common"
 	istiov1alpha1 "github.com/kartverket/skiperator/api/common/istiotypes"
 	"github.com/kartverket/skiperator/api/common/podtypes"
 	"github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/pkg/testutil"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -59,6 +61,24 @@ func TestStatusDiffWithTimestamp(t *testing.T) {
 	diff, err := GetObjectDiff(tmpStatus, status)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(diff))
+}
+
+func TestClearGatewayAPIConditions(t *testing.T) {
+	now := v1.Now()
+	app := &v1alpha1.Application{}
+	app.GetStatus().MigrationStartedAt = &now
+	app.GetStatus().SetReadyCondition(v1.ConditionTrue, 1, "Reconciled", "ready")
+	app.GetStatus().SetStandardRoutingReadyCondition(v1.ConditionFalse, 1, "MigrationStalled", "stalled")
+	app.GetStatus().SetLegacyRoutingActiveCondition(v1.ConditionTrue, 1, "LegacyRoutingActive", "active")
+	app.GetStatus().SetSharedRoutingResourcesCondition(v1.ConditionTrue, 1, "SharedRoutingResourcesActive", "shared")
+
+	ClearGatewayAPIConditions(app)
+
+	assert.Nil(t, app.GetStatus().MigrationStartedAt)
+	assert.NotNil(t, meta.FindStatusCondition(app.Status.Conditions, commontypes.ReadyConditionType))
+	assert.Nil(t, meta.FindStatusCondition(app.Status.Conditions, commontypes.StandardRoutingReadyConditionType))
+	assert.Nil(t, meta.FindStatusCondition(app.Status.Conditions, commontypes.LegacyRoutingActiveConditionType))
+	assert.Nil(t, meta.FindStatusCondition(app.Status.Conditions, commontypes.SharedRoutingResourcesType))
 }
 
 func TestShouldNormalizeHosts(t *testing.T) {

--- a/internal/controllers/gatewayapi_conflicts_test.go
+++ b/internal/controllers/gatewayapi_conflicts_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	commontypes "github.com/kartverket/skiperator/api/common"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	controllercommon "github.com/kartverket/skiperator/internal/controllers/common"
 	"github.com/kartverket/skiperator/pkg/mesh"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -94,6 +96,26 @@ func TestApplicationStandardRoutingAllowsAmbientNamespace(t *testing.T) {
 	err = reconciler.ValidateIstioEnabledForGatewayAPI(application.UsesStandardRouting(), meshMode, application.Namespace)
 
 	require.NoError(t, err)
+}
+
+func TestRoutingSharedOwnershipSetsSharedResourcesCondition(t *testing.T) {
+	routing := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "api.example.com",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+			Ownership:       skiperatorv1alpha1.RoutingOwnershipShared,
+			Routes:          []skiperatorv1alpha1.Route{{TargetApp: "backend", PathPrefix: "/", Port: 8080}},
+		},
+	}
+
+	setSharedRoutingResourcesCondition(routing)
+
+	condition := meta.FindStatusCondition(routing.Status.Conditions, commontypes.SharedRoutingResourcesType)
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, "SharedRoutingResourcesActive", condition.Reason)
+	}
 }
 
 func TestRoutingCertificateWatchUsesRoutingLabels(t *testing.T) {

--- a/internal/controllers/routing.go
+++ b/internal/controllers/routing.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	commontypes "github.com/kartverket/skiperator/api/common"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/internal/controllers/common"
 	"github.com/kartverket/skiperator/pkg/gwapi"
@@ -24,15 +25,21 @@ import (
 	istionetworkingv1 "istio.io/client-go/pkg/apis/networking/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+// sharedRoutingFinalizer drives ref-counted cleanup of shared Gateway API
+// resources in istio-gateways, which are not owned by any single contributor.
+const sharedRoutingFinalizer = "skiperator.kartverket.no/shared-routing-cleanup"
 
 // +kubebuilder:rbac:groups=skiperator.kartverket.no,resources=routings;routings/status,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=skiperator.kartverket.no,resources=applications;applications/status,verbs=get;list;watch
@@ -85,6 +92,13 @@ func (r *RoutingReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	} else if err != nil {
 		r.EmitWarningEvent(routing, "ReconcileStartFail", "something went wrong fetching the Routing, it might have been deleted")
 		return common.RequeueWithError(err)
+	}
+
+	// Shared routing resources in istio-gateways are not owned by any single
+	// contributor, so a finalizer drives ref-counted cleanup when the last
+	// contributor for a hostname is deleted.
+	if handled, result, err := r.reconcileSharedRoutingFinalizer(ctx, routing, rLog); handled {
+		return result, err
 	}
 
 	if !common.ShouldReconcile(routing) {
@@ -152,6 +166,22 @@ func (r *RoutingReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		emitMigrationEvents(&r.ReconcilerBase, routing, gwapi.UpdateRoutingStatus(routing.GetStatus(), routing.GetGeneration(), routingState))
 	}
 
+	// Register before generating/applying shared resources. The finalizer is
+	// added in an earlier reconcile pass, and tests/users may observe shared
+	// resources before every contributor has completed status updates. A visible
+	// shared resource must therefore never precede its membership entry.
+	if routing.UsesSharedOwnership() {
+		host, err := routing.Spec.GetHost()
+		if err != nil {
+			r.SetErrorState(ctx, routing, err, "failed to resolve shared routing host", "SharedRoutingHostFailure")
+			return common.RequeueWithError(err)
+		}
+		if err := gwapi.RegisterSharedContributor(ctx, r.GetClient(), host.Hostname, types.NamespacedName{Namespace: routing.Namespace, Name: routing.Name}); err != nil {
+			r.SetErrorState(ctx, routing, err, "failed to register shared routing contributor", "SharedRoutingMembershipFailure")
+			return common.RequeueWithError(err)
+		}
+	}
+
 	resourceGeneration := []reconciliationFunc{
 		networkpolicy.Generate,
 		virtualservice.Generate,
@@ -197,12 +227,25 @@ func (r *RoutingReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	// Ready/summary come from the shared routing-status assembler, the same path
 	// Application uses, so the two controllers cannot drift.
 	finalizeRoutingStatus(&r.ReconcilerBase, routing, routingState, "Routing has been reconciled")
+	if routing.UsesStandardRouting() {
+		setSharedRoutingResourcesCondition(routing)
+	}
 	r.UpdateStatus(ctx, routing)
 	if routing.UsesStandardRouting() && !routingState.Readiness.Ready {
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	return common.DoNotRequeue()
+}
+
+// setSharedRoutingResourcesCondition exposes shared Gateway API infrastructure
+// only when active, without adding conditions to standalone Routing objects.
+func setSharedRoutingResourcesCondition(routing *skiperatorv1alpha1.Routing) {
+	if routing.UsesSharedOwnership() {
+		common.SetSharedRoutingResourcesActive(routing)
+		return
+	}
+	common.ClearSharedRoutingResourcesCondition(routing)
 }
 
 func (r *RoutingReconciler) getRouting(ctx context.Context, req reconcile.Request) (*skiperatorv1alpha1.Routing, error) {
@@ -231,6 +274,103 @@ func (r *RoutingReconciler) cleanUpWatchedResources(ctx context.Context, name ty
 // reconcileSharedRoutingFinalizer adds/removes the shared-routing finalizer and,
 // on deletion, performs ref-counted cleanup of shared istio-gateways resources.
 // It returns handled=true when it owns the outcome of this reconcile pass.
+func (r *RoutingReconciler) reconcileSharedRoutingFinalizer(ctx context.Context, routing *skiperatorv1alpha1.Routing, rLog log.Logger) (bool, reconcile.Result, error) {
+	if !routing.GetDeletionTimestamp().IsZero() {
+		if !ctrlutil.ContainsFinalizer(routing, sharedRoutingFinalizer) {
+			return true, reconcile.Result{}, nil
+		}
+		if err := r.handleSharedRoutingDeletion(ctx, routing, rLog); err != nil {
+			return true, reconcile.Result{}, err
+		}
+		ctrlutil.RemoveFinalizer(routing, sharedRoutingFinalizer)
+		if err := r.GetClient().Update(ctx, routing); err != nil {
+			return true, reconcile.Result{}, err
+		}
+		return true, reconcile.Result{}, nil
+	}
+
+	hasFinalizer := ctrlutil.ContainsFinalizer(routing, sharedRoutingFinalizer)
+	// Add the finalizer for shared routings, remove it if a Routing switched away
+	// from shared ownership. Requeue so the rest of the reconcile runs cleanly.
+	if routing.UsesSharedOwnership() && !hasFinalizer {
+		ctrlutil.AddFinalizer(routing, sharedRoutingFinalizer)
+		if err := r.GetClient().Update(ctx, routing); err != nil {
+			return true, reconcile.Result{}, err
+		}
+		return true, reconcile.Result{Requeue: true}, nil
+	}
+	if !routing.UsesSharedOwnership() && hasFinalizer {
+		// Switched away from shared ownership: release membership so the shared
+		// resources are cleaned up if this was the last contributor.
+		if err := r.releaseSharedMembership(ctx, routing, rLog); err != nil {
+			return true, reconcile.Result{}, err
+		}
+		ctrlutil.RemoveFinalizer(routing, sharedRoutingFinalizer)
+		if err := r.GetClient().Update(ctx, routing); err != nil {
+			return true, reconcile.Result{}, err
+		}
+		return true, reconcile.Result{Requeue: true}, nil
+	}
+	return false, reconcile.Result{}, nil
+}
+
+// handleSharedRoutingDeletion prunes the deleted Routing's own resources, then
+// releases its shared-routing membership.
+func (r *RoutingReconciler) handleSharedRoutingDeletion(ctx context.Context, routing *skiperatorv1alpha1.Routing, rLog log.Logger) error {
+	if errs := r.cleanUpWatchedResources(ctx, types.NamespacedName{Namespace: routing.Namespace, Name: routing.Name}); len(errs) > 0 {
+		return fmt.Errorf("failed to clean up routing resources: %w", errs[0])
+	}
+	return r.releaseSharedMembership(ctx, routing, rLog)
+}
+
+// releaseSharedMembership deregisters this Routing from its hostname's shared
+// membership and, when it was the last contributor, deletes the shared
+// istio-gateways resources and the membership ConfigMap. Used both on deletion
+// and when a Routing switches away from shared ownership.
+func (r *RoutingReconciler) releaseSharedMembership(ctx context.Context, routing *skiperatorv1alpha1.Routing, rLog log.Logger) error {
+	host, err := routing.Spec.GetHost()
+	if err != nil {
+		return err
+	}
+	empty, err := gwapi.DeregisterSharedContributor(ctx, r.GetClient(), host.Hostname, types.NamespacedName{Namespace: routing.Namespace, Name: routing.Name})
+	if err != nil {
+		return err
+	}
+	if !empty {
+		rLog.Debug("Other shared Routings still use hostname, keeping shared resources", "hostname", host.Hostname)
+		return nil
+	}
+	if err := r.deleteSharedRoutingResources(ctx, routing, host); err != nil {
+		return err
+	}
+	return gwapi.DeleteSharedMembership(ctx, r.GetClient(), host.Hostname)
+}
+
+// deleteSharedRoutingResources deletes the shared ListenerSet, redirect HTTPRoute
+// and certificate for a hostname from istio-gateways. Missing resources are
+// ignored so the cleanup is idempotent.
+func (r *RoutingReconciler) deleteSharedRoutingResources(ctx context.Context, routing *skiperatorv1alpha1.Routing, host *commontypes.Host) error {
+	resources := []client.Object{
+		&gatewayapiv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{Namespace: gwapi.IstioGatewayNamespace, Name: gwapi.SharedListenerSetName(host.Hostname)}},
+		&gatewayapiv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: gwapi.IstioGatewayNamespace, Name: gwapi.SharedRedirectRouteName(host.Hostname)}},
+	}
+	if !host.UsesCustomCert() {
+		certName, err := routing.GetCertificateName(host)
+		if err != nil {
+			return err
+		}
+		resources = append(resources, &certmanagerv1.Certificate{ObjectMeta: metav1.ObjectMeta{Namespace: gwapi.IstioGatewayNamespace, Name: certName}})
+	}
+
+	for _, obj := range resources {
+		if err := r.GetClient().Delete(ctx, obj); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete shared routing resource %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	return nil
+}
+
+// TODO Do this with application too for dynamic port allocation?
 func (r *RoutingReconciler) setDefaultSpec(ctx context.Context, routing *skiperatorv1alpha1.Routing) (map[string]int32, error) {
 	targetAppPorts := make(map[string]int32)
 	for i := range routing.Spec.Routes {
@@ -253,13 +393,32 @@ func (r *RoutingReconciler) setDefaultSpec(ctx context.Context, routing *skipera
 }
 
 func (r *RoutingReconciler) setRoutingResourceDefaults(resources []client.Object, routing *skiperatorv1alpha1.Routing) error {
+	host, err := routing.Spec.GetHost()
+	if err != nil {
+		return err
+	}
 	if err := r.SetSubresourceDefaults(resources, routing); err != nil {
 		return err
 	}
 	for _, resource := range resources {
+		if routing.UsesSharedOwnership() && resource.GetNamespace() == gwapi.IstioGatewayNamespace && isSharedRoutingInfrastructure(resource) {
+			resourceutils.SetSharedRoutingLabels(resource, host.Hostname)
+			continue
+		}
 		resourceutils.SetRoutingLabels(resource, routing)
 	}
 	return nil
+}
+
+// isSharedRoutingInfrastructure selects the cross-namespace objects whose
+// labels must be stable across all Routing contributors for one hostname.
+func isSharedRoutingInfrastructure(resource client.Object) bool {
+	switch resource.(type) {
+	case *certmanagerv1.Certificate, *gatewayapiv1.ListenerSet, *gatewayapiv1.HTTPRoute:
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *RoutingReconciler) skiperatorApplicationsChanges(context context.Context, obj client.Object) []reconcile.Request {

--- a/internal/controllers/routing_finalizer_test.go
+++ b/internal/controllers/routing_finalizer_test.go
@@ -1,0 +1,161 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
+	controllercommon "github.com/kartverket/skiperator/internal/controllers/common"
+	"github.com/kartverket/skiperator/pkg/gwapi"
+	"github.com/kartverket/skiperator/pkg/log"
+	"github.com/kartverket/skiperator/pkg/resourceschemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func sharedRouting(namespace, name, hostname string) *skiperatorv1alpha1.Routing {
+	return &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        hostname,
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+			Ownership:       skiperatorv1alpha1.RoutingOwnershipShared,
+		},
+	}
+}
+
+func TestSharedRoutingDeletesSharedResourcesOnlyForLastContributor(t *testing.T) {
+	ctx := context.Background()
+	hostname := "shared.example.com"
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+
+	teamA := sharedRouting("team-a", "api", hostname)
+	teamB := sharedRouting("team-b", "web", hostname)
+	sharedListenerSet := &gatewayapiv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: gwapi.IstioGatewayNamespace, Name: gwapi.SharedListenerSetName(hostname)},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(teamA, teamB, sharedListenerSet).Build()
+	reconciler := &RoutingReconciler{ReconcilerBase: controllercommon.NewReconcilerBase(c, nil, scheme, nil, nil)}
+
+	// Both contributors register their membership.
+	require.NoError(t, gwapi.RegisterSharedContributor(ctx, c, hostname, types.NamespacedName{Namespace: "team-a", Name: "api"}))
+	require.NoError(t, gwapi.RegisterSharedContributor(ctx, c, hostname, types.NamespacedName{Namespace: "team-b", Name: "web"}))
+
+	// Releasing team-a leaves team-b: shared resources are kept.
+	require.NoError(t, reconciler.releaseSharedMembership(ctx, teamA, log.NewLogger()))
+	err := c.Get(ctx, types.NamespacedName{Namespace: gwapi.IstioGatewayNamespace, Name: gwapi.SharedListenerSetName(hostname)}, &gatewayapiv1.ListenerSet{})
+	require.NoError(t, err)
+
+	// Releasing the last contributor deletes the shared resources and membership.
+	require.NoError(t, reconciler.releaseSharedMembership(ctx, teamB, log.NewLogger()))
+	err = c.Get(ctx, types.NamespacedName{Namespace: gwapi.IstioGatewayNamespace, Name: gwapi.SharedListenerSetName(hostname)}, &gatewayapiv1.ListenerSet{})
+	assert.True(t, apierrors.IsNotFound(err))
+	err = c.Get(ctx, types.NamespacedName{Namespace: gwapi.IstioGatewayNamespace, Name: gwapi.SharedMembershipName(hostname)}, &corev1.ConfigMap{})
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestSharedRoutingRegistersMembershipBeforeApplyingResources(t *testing.T) {
+	ctx := context.Background()
+	hostname := "shared.example.com"
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+
+	// The fixture is the smallest valid shared Gateway API Routing reconcile:
+	// an Istio-enabled namespace, one target Application for route port lookup,
+	// and one shared Routing that should create shared istio-gateways resources.
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "team-a",
+			Labels: map[string]string{"istio.io/rev": "revision"},
+		},
+	}
+	application := &skiperatorv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.ApplicationSpec{
+			Image: "image",
+			Port:  8080,
+		},
+	}
+	routing := sharedRouting("team-a", "api", hostname)
+	routing.Spec.Routes = []skiperatorv1alpha1.Route{{TargetApp: "app", PathPrefix: "/", Port: 8080}}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(routing).
+		WithObjects(namespace, application, routing).
+		Build()
+	reconciler := &RoutingReconciler{
+		ReconcilerBase: controllercommon.NewReconcilerBase(c, nil, scheme, nil, record.NewFakeRecorder(10)),
+	}
+
+	// First pass adds the finalizer and stops. Deletion cleanup depends on this finalizer, but membership registration happens in a later full reconcile.
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "team-a", Name: "api"}})
+	require.NoError(t, err)
+	updatedRouting := &skiperatorv1alpha1.Routing{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "api"}, updatedRouting))
+	require.True(t, ctrlutil.ContainsFinalizer(updatedRouting, sharedRoutingFinalizer))
+
+	// Drive reconcile until the shared ListenerSet has actually been applied.
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "team-a", Name: "api"}}
+	for i := 0; i < 10; i++ {
+		_, err = reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		err = c.Get(ctx, types.NamespacedName{Namespace: gwapi.IstioGatewayNamespace, Name: gwapi.SharedListenerSetName(hostname)}, &gatewayapiv1.ListenerSet{})
+		if err == nil {
+			break
+		}
+		require.True(t, apierrors.IsNotFound(err))
+	}
+
+	// Once shared resources are visible, the contributor must already be in the
+	// membership ConfigMap. Otherwise deleting another contributor can see an
+	// incomplete membership set and delete shared resources too early.
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: gwapi.IstioGatewayNamespace, Name: gwapi.SharedMembershipName(hostname)}, cm))
+	assert.Contains(t, cm.Data, "team-a.api")
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: gwapi.IstioGatewayNamespace, Name: gwapi.SharedListenerSetName(hostname)}, &gatewayapiv1.ListenerSet{}))
+}
+
+// A custom certificate is provisioned manually into istio-gateways and is not
+// owned by skiperator, so the GC must never delete it (only the shared
+// ListenerSet, which skiperator does own).
+func TestSharedRoutingDoesNotDeleteCustomCertificate(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+
+	routing := sharedRouting("team-a", "api", "shared.example.com+manual-tls")
+	host, err := routing.Spec.GetHost()
+	require.NoError(t, err)
+	require.True(t, host.UsesCustomCert())
+
+	customCert := &certmanagerv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: gwapi.IstioGatewayNamespace, Name: "manual-tls"},
+	}
+	sharedListenerSet := &gatewayapiv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: gwapi.IstioGatewayNamespace, Name: gwapi.SharedListenerSetName(host.Hostname)},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(routing, customCert, sharedListenerSet).Build()
+	reconciler := &RoutingReconciler{ReconcilerBase: controllercommon.NewReconcilerBase(c, nil, scheme, nil, nil)}
+
+	require.NoError(t, gwapi.RegisterSharedContributor(ctx, c, host.Hostname, types.NamespacedName{Namespace: "team-a", Name: "api"}))
+	require.NoError(t, reconciler.releaseSharedMembership(ctx, routing, log.NewLogger()))
+
+	// The shared ListenerSet (skiperator-owned) is removed.
+	err = c.Get(ctx, types.NamespacedName{Namespace: gwapi.IstioGatewayNamespace, Name: gwapi.SharedListenerSetName(host.Hostname)}, &gatewayapiv1.ListenerSet{})
+	assert.True(t, apierrors.IsNotFound(err))
+	// The manually-provisioned custom certificate is left untouched.
+	err = c.Get(ctx, types.NamespacedName{Namespace: gwapi.IstioGatewayNamespace, Name: "manual-tls"}, &certmanagerv1.Certificate{})
+	require.NoError(t, err)
+}

--- a/pkg/gwapi/conflicts.go
+++ b/pkg/gwapi/conflicts.go
@@ -86,8 +86,8 @@ func validateRoutingConflicts(ctx context.Context, c client.Client, routing *ski
 	return nil
 }
 
-// validateRoutingHostnameOwnership prevents a Routing from attaching to a
-// hostname already claimed by another object's ListenerSet.
+// validateRoutingHostnameOwnership prevents standalone Routing from attaching
+// to a hostname already claimed by shared or application-owned ListenerSets.
 func validateRoutingHostnameOwnership(ctx context.Context, c client.Client, routing *skiperatorv1alpha1.Routing, hostname string) error {
 	listenerSets := &gatewayapiv1.ListenerSetList{}
 	if err := c.List(ctx, listenerSets); err != nil {
@@ -102,6 +102,9 @@ func validateRoutingHostnameOwnership(ctx context.Context, c client.Client, rout
 		}
 		for _, listener := range listenerSet.Spec.Listeners {
 			if !listenerCoversHostname(listener.Hostname, hostname) {
+				continue
+			}
+			if routing.UsesSharedOwnership() && sharedRoutingListenerSet(listenerSet.Labels, listenerSet.Name, hostname) {
 				continue
 			}
 			if listenerSetAccepted(listenerSet) {
@@ -140,6 +143,13 @@ func sameRouting(labels map[string]string, routing *skiperatorv1alpha1.Routing) 
 	return labels["skiperator.kartverket.no/controller"] == "routing" &&
 		labels["skiperator.kartverket.no/routing-name"] == routing.Name &&
 		labels["skiperator.kartverket.no/source-namespace"] == routing.Namespace
+}
+
+// sharedRoutingListenerSet identifies the one shared ListenerSet that all
+// shared Routing objects for a hostname are allowed to reuse.
+func sharedRoutingListenerSet(labels map[string]string, name string, hostname string) bool {
+	return labels["skiperator.kartverket.no/controller"] == "routing-shared" &&
+		name == SharedListenerSetName(hostname)
 }
 
 func isRedirectRoute(route gatewayapiv1.HTTPRoute) bool {

--- a/pkg/gwapi/membership.go
+++ b/pkg/gwapi/membership.go
@@ -1,0 +1,136 @@
+package gwapi
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kartverket/skiperator/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Shared Gateway API routing resources (ListenerSet, redirect HTTPRoute,
+// Certificate) live in istio-gateways and are contributed to by Routing objects
+// in many namespaces. Kubernetes ownerReferences cannot cross namespaces, so the
+// shared resources cannot be garbage-collected by owner refs. Instead a single
+// membership ConfigMap per hostname tracks the live contributors: each contributor
+// registers itself on reconcile and deregisters via its finalizer, and the shared
+// resources are deleted once the membership is empty. This is a precise ref-count
+// — no cluster-wide Routing scan and no peer-spec parsing.
+
+// SharedMembershipName returns the name of the membership ConfigMap for hostname.
+func SharedMembershipName(hostname string) string {
+	return fmt.Sprintf("shared-routing-members-%x", util.GenerateHashFromName(hostname))
+}
+
+// contributorKey is the ConfigMap data key for one contributing Routing.
+// Namespaces are DNS labels (no dots), so "<namespace>.<name>" is unambiguous and
+// is a valid ConfigMap data key.
+func contributorKey(contributor types.NamespacedName) string {
+	return contributor.Namespace + "." + contributor.Name
+}
+
+// RegisterSharedContributor records that contributor uses the shared resources
+// for hostname, creating the membership ConfigMap if it does not exist yet.
+// Idempotent.
+func RegisterSharedContributor(ctx context.Context, c client.Client, hostname string, contributor types.NamespacedName) error {
+	key := types.NamespacedName{Namespace: IstioGatewayNamespace, Name: SharedMembershipName(hostname)}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm := &corev1.ConfigMap{}
+		err := c.Get(ctx, key, cm)
+		if apierrors.IsNotFound(err) {
+			created := newMembershipConfigMap(hostname)
+			created.Data = map[string]string{contributorKey(contributor): ""}
+			if createErr := c.Create(ctx, created); createErr == nil {
+				return nil
+			} else if !apierrors.IsAlreadyExists(createErr) {
+				return createErr
+			}
+			// Lost the create race — re-read and fall through to update.
+			if err = c.Get(ctx, key, cm); err != nil {
+				return err
+			}
+		} else if err != nil {
+			return err
+		}
+		if _, ok := cm.Data[contributorKey(contributor)]; ok {
+			return nil
+		}
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data[contributorKey(contributor)] = ""
+		return c.Update(ctx, cm)
+	})
+}
+
+// DeregisterSharedContributor removes contributor from hostname's membership.
+// Returns empty=true and deletes the membership ConfigMap when no contributors
+// remain, closing the TOCTOU window between checking empty and deletion. The
+// deletion is preconditioned on the ResourceVersion from the read; a concurrent
+// RegisterSharedContributor that inserts between the read and delete will cause
+// a Conflict that RetryOnConflict resolves by re-reading the updated membership.
+// A missing ConfigMap is treated as "no contributors remain".
+func DeregisterSharedContributor(ctx context.Context, c client.Client, hostname string, contributor types.NamespacedName) (empty bool, err error) {
+	key := types.NamespacedName{Namespace: IstioGatewayNamespace, Name: SharedMembershipName(hostname)}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm := &corev1.ConfigMap{}
+		getErr := c.Get(ctx, key, cm)
+		if apierrors.IsNotFound(getErr) {
+			empty = true
+			return nil
+		}
+		if getErr != nil {
+			return getErr
+		}
+		delete(cm.Data, contributorKey(contributor))
+		if len(cm.Data) == 0 {
+			// Delete the ConfigMap here, using the ResourceVersion from the Get
+			// as a precondition. If a concurrent Register slips in between, the
+			// delete will return Conflict; RetryOnConflict re-reads and finds the
+			// new contributor, so empty stays false and the CM is not deleted.
+			if deleteErr := c.Delete(ctx, cm); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+				return deleteErr
+			}
+			empty = true
+			return nil
+		}
+		empty = false
+		return c.Update(ctx, cm)
+	})
+	return empty, err
+}
+
+// DeleteSharedMembership removes the membership ConfigMap for hostname. Idempotent.
+func DeleteSharedMembership(ctx context.Context, c client.Client, hostname string) error {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: IstioGatewayNamespace, Name: SharedMembershipName(hostname)}}
+	if err := c.Delete(ctx, cm); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete shared routing membership %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+	return nil
+}
+
+// SharedRoutingLabels are the labels every shared routing object for a hostname
+// carries, whichever Routing happened to create it.
+func SharedRoutingLabels(hostname string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by":        "skiperator",
+		"skiperator.kartverket.no/controller": "routing-shared",
+		"skiperator.kartverket.no/hostname":   fmt.Sprintf("%x", util.GenerateHashFromName(strings.ToLower(hostname))),
+	}
+}
+
+func newMembershipConfigMap(hostname string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: IstioGatewayNamespace,
+			Name:      SharedMembershipName(hostname),
+			Labels:    SharedRoutingLabels(hostname),
+		},
+	}
+}

--- a/pkg/gwapi/membership_test.go
+++ b/pkg/gwapi/membership_test.go
@@ -1,0 +1,179 @@
+package gwapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func membershipClient(t *testing.T) *fake.ClientBuilder {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, scheme.AddToScheme(s))
+	return fake.NewClientBuilder().WithScheme(s)
+}
+
+func TestRegisterSharedContributorCreatesAndAccumulates(t *testing.T) {
+	ctx := context.Background()
+	c := membershipClient(t).Build()
+	hostname := "shared.example.com"
+
+	require.NoError(t, RegisterSharedContributor(ctx, c, hostname, types.NamespacedName{Namespace: "team-a", Name: "api"}))
+	// Idempotent re-register and a second contributor.
+	require.NoError(t, RegisterSharedContributor(ctx, c, hostname, types.NamespacedName{Namespace: "team-a", Name: "api"}))
+	require.NoError(t, RegisterSharedContributor(ctx, c, hostname, types.NamespacedName{Namespace: "team-b", Name: "web"}))
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: IstioGatewayNamespace, Name: SharedMembershipName(hostname)}, cm))
+	assert.Len(t, cm.Data, 2)
+	assert.Contains(t, cm.Data, "team-a.api")
+	assert.Contains(t, cm.Data, "team-b.web")
+}
+
+func TestDeregisterSharedContributorReportsEmptyOnlyWhenLast(t *testing.T) {
+	ctx := context.Background()
+	c := membershipClient(t).Build()
+	hostname := "shared.example.com"
+	require.NoError(t, RegisterSharedContributor(ctx, c, hostname, types.NamespacedName{Namespace: "team-a", Name: "api"}))
+	require.NoError(t, RegisterSharedContributor(ctx, c, hostname, types.NamespacedName{Namespace: "team-b", Name: "web"}))
+
+	empty, err := DeregisterSharedContributor(ctx, c, hostname, types.NamespacedName{Namespace: "team-a", Name: "api"})
+	require.NoError(t, err)
+	assert.False(t, empty)
+
+	// CM still exists with one contributor.
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: IstioGatewayNamespace, Name: SharedMembershipName(hostname)}, cm))
+
+	empty, err = DeregisterSharedContributor(ctx, c, hostname, types.NamespacedName{Namespace: "team-b", Name: "web"})
+	require.NoError(t, err)
+	assert.True(t, empty)
+
+	// CM must be deleted once the last contributor leaves.
+	err = c.Get(ctx, types.NamespacedName{Namespace: IstioGatewayNamespace, Name: SharedMembershipName(hostname)}, &corev1.ConfigMap{})
+	assert.True(t, errors.IsNotFound(err), "ConfigMap must be deleted after last contributor deregisters")
+}
+
+// TestDeregisterSharedContributorConcurrentRegister verifies the TOCTOU fix:
+// if a concurrent RegisterSharedContributor adds a key between our read and
+// delete, the Delete returns Conflict, RetryOnConflict re-reads the CM, and
+// Deregister correctly returns empty=false without deleting the CM.
+func TestDeregisterSharedContributorConcurrentRegister(t *testing.T) {
+	ctx := context.Background()
+	hostname := "shared.example.com"
+	contributor := types.NamespacedName{Namespace: "team-a", Name: "api"}
+	newcomer := types.NamespacedName{Namespace: "team-c", Name: "svc"}
+
+	// Seed CM with just contributor so Deregister will try to delete it.
+	existing := newMembershipConfigMap(hostname)
+	existing.Data = map[string]string{contributorKey(contributor): ""}
+
+	// On the first Delete, inject a concurrent Register (add newcomer to the store),
+	// then return Conflict so RetryOnConflict re-reads the updated CM.
+	deleteCalled := false
+	c := membershipClient(t).
+		WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*corev1.ConfigMap); ok && !deleteCalled {
+					deleteCalled = true
+					key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+					cm := &corev1.ConfigMap{}
+					if err := cl.Get(ctx, key, cm); err != nil {
+						return err
+					}
+					if cm.Data == nil {
+						cm.Data = map[string]string{}
+					}
+					cm.Data[contributorKey(newcomer)] = ""
+					if err := cl.Update(ctx, cm); err != nil {
+						return err
+					}
+					return errors.NewConflict(corev1.Resource("configmaps"), obj.GetName(), nil)
+				}
+				return cl.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	empty, err := DeregisterSharedContributor(ctx, c, hostname, contributor)
+	require.NoError(t, err)
+	assert.False(t, empty, "concurrent register must prevent empty=true")
+	assert.True(t, deleteCalled, "delete must have been attempted")
+
+	// CM must still exist with only the newcomer.
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: IstioGatewayNamespace, Name: SharedMembershipName(hostname)}, cm))
+	assert.NotContains(t, cm.Data, contributorKey(contributor))
+	assert.Contains(t, cm.Data, contributorKey(newcomer))
+}
+
+func TestDeregisterSharedContributorMissingConfigMapIsEmpty(t *testing.T) {
+	ctx := context.Background()
+	c := membershipClient(t).Build()
+
+	empty, err := DeregisterSharedContributor(ctx, c, "shared.example.com", types.NamespacedName{Namespace: "team-a", Name: "api"})
+	require.NoError(t, err)
+	assert.True(t, empty)
+}
+
+func TestRegisterSharedContributorHandlesCreateRace(t *testing.T) {
+	ctx := context.Background()
+	hostname := "shared.example.com"
+	contributor := types.NamespacedName{Namespace: "team-a", Name: "api"}
+
+	// Pre-seed ConfigMap as if another writer already created it (without our contributor key).
+	existing := newMembershipConfigMap(hostname)
+	existing.Data = map[string]string{"team-b.web": ""}
+
+	// Simulate the create race:
+	//   1. Intercept the first Get to return NotFound (our goroutine reads before the CM exists).
+	//   2. We then call Create; the fake client returns AlreadyExists because CM is in the store.
+	//   3. RegisterSharedContributor re-reads and falls through to Update.
+	getCount := 0
+	c := membershipClient(t).
+		WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.ConfigMap); ok && getCount == 0 {
+					getCount++
+					return errors.NewNotFound(corev1.Resource("configmaps"), key.Name)
+				}
+				getCount++
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	require.NoError(t, RegisterSharedContributor(ctx, c, hostname, contributor))
+	assert.GreaterOrEqual(t, getCount, 2, "must re-read after AlreadyExists")
+
+	cm := &corev1.ConfigMap{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: IstioGatewayNamespace, Name: SharedMembershipName(hostname)}, cm))
+	assert.Contains(t, cm.Data, "team-a.api")
+	assert.Contains(t, cm.Data, "team-b.web")
+}
+
+func TestDeleteSharedMembershipIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	c := membershipClient(t).Build()
+	hostname := "shared.example.com"
+	require.NoError(t, RegisterSharedContributor(ctx, c, hostname, types.NamespacedName{Namespace: "team-a", Name: "api"}))
+
+	require.NoError(t, DeleteSharedMembership(ctx, c, hostname))
+	// Second delete on a missing ConfigMap must not error.
+	require.NoError(t, DeleteSharedMembership(ctx, c, hostname))
+
+	err := c.Get(ctx, types.NamespacedName{Namespace: IstioGatewayNamespace, Name: SharedMembershipName(hostname)}, &corev1.ConfigMap{})
+	assert.True(t, errors.IsNotFound(err))
+}

--- a/pkg/gwapi/names.go
+++ b/pkg/gwapi/names.go
@@ -38,7 +38,17 @@ func ListenerSetName(prefix string, hostname string) string {
 	return fmt.Sprintf("%s-listener-%x", prefix, util.GenerateHashFromName(hostname))
 }
 
+// SharedListenerSetName returns generated shared ListenerSet name for hostname.
+func SharedListenerSetName(hostname string) string {
+	return ListenerSetName("shared", hostname)
+}
+
 // RedirectRouteName returns HTTP-to-HTTPS redirect HTTPRoute name.
 func RedirectRouteName(prefix string) string {
 	return fmt.Sprintf("%s-redirect", prefix)
+}
+
+// SharedRedirectRouteName returns generated shared redirect HTTPRoute name for hostname.
+func SharedRedirectRouteName(hostname string) string {
+	return RedirectRouteName(fmt.Sprintf("shared-%x", util.GenerateHashFromName(hostname)))
 }

--- a/pkg/gwapi/planner.go
+++ b/pkg/gwapi/planner.go
@@ -72,6 +72,7 @@ func (p routingPlanner) readinessPlan() (readinessPlan, error) {
 		redirectToHTTPS: p.GetRedirectToHTTPS(),
 		hosts:           hosts,
 		certificateName: p.GetCertificateName,
+		sharedRouting:   p.UsesSharedOwnership(),
 	})
 }
 

--- a/pkg/gwapi/readiness.go
+++ b/pkg/gwapi/readiness.go
@@ -44,6 +44,7 @@ type planInput struct {
 	redirectToHTTPS bool
 	hosts           common.HostCollection
 	certificateName func(*common.Host) (string, error)
+	sharedRouting   bool
 }
 
 // readinessPlan is the fully-resolved set of probe targets for one routable.
@@ -118,22 +119,32 @@ func buildReadinessPlan(in planInput) (readinessPlan, error) {
 		routes: []routeCheck{{Namespace: in.namespace, Name: in.routeBaseName}},
 	}
 	if in.redirectToHTTPS {
-		plan.routes = append(plan.routes, routeCheck{Namespace: in.namespace, Name: RedirectRouteName(in.routeBaseName)})
+		redirectRoute := routeCheck{Namespace: in.namespace, Name: RedirectRouteName(in.routeBaseName)}
+		if in.sharedRouting {
+			redirectRoute.Namespace = IstioGatewayNamespace
+			redirectRoute.Name = SharedRedirectRouteName(in.hosts.AllHosts()[0].Hostname)
+		}
+		plan.routes = append(plan.routes, redirectRoute)
 	}
 	for _, host := range in.hosts.AllHosts() {
 		name, err := in.certificateName(host)
 		if err != nil {
 			return readinessPlan{}, err
 		}
+		namespace := in.namespace
+		// Key off the (kind-qualified) base name, the same prefix the generator
+		// uses, so Application and Routing ListenerSets stay distinct.
+		listenerSetName := ListenerSetName(in.routeBaseName, host.Hostname)
+		if in.sharedRouting {
+			namespace = IstioGatewayNamespace
+			listenerSetName = SharedListenerSetName(host.Hostname)
+		}
 		plan.hosts = append(plan.hosts, standardHost{
 			Hostname:        host.Hostname,
 			CertificateName: name,
 			CustomSecret:    host.CustomCertificateSecret,
-			Namespace:       in.namespace,
-			// Key off the (kind-qualified) base name, the same prefix the
-			// generator uses, so Application and Routing ListenerSets stay
-			// distinct.
-			ListenerSetName: ListenerSetName(in.routeBaseName, host.Hostname),
+			Namespace:       namespace,
+			ListenerSetName: listenerSetName,
 		})
 	}
 	return plan, nil

--- a/pkg/gwapi/routing_state_test.go
+++ b/pkg/gwapi/routing_state_test.go
@@ -315,6 +315,32 @@ func TestRoutingConflictIgnoresRedirectRoute(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRoutingStandaloneConflictsWithSharedListenerSet(t *testing.T) {
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+	listenerSet := readySharedRoutingListenerSet("API.example.COM")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(listenerSet).Build()
+	routing := gatewayAPIRouting()
+
+	err := ValidateConflicts(context.Background(), c, routing)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already has an accepted ListenerSet")
+}
+
+func TestRoutingSharedOwnershipAllowsSharedListenerSet(t *testing.T) {
+	scheme := runtime.NewScheme()
+	resourceschemas.AddSchemas(scheme)
+	listenerSet := readySharedRoutingListenerSet("api.example.com")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(listenerSet).Build()
+	routing := gatewayAPIRouting()
+	routing.Spec.Ownership = skiperatorv1alpha1.RoutingOwnershipShared
+
+	err := ValidateConflicts(context.Background(), c, routing)
+
+	require.NoError(t, err)
+}
+
 func TestRoutingStandardRoutingKeepsLegacyUntilReady(t *testing.T) {
 	scheme := runtime.NewScheme()
 	resourceschemas.AddSchemas(scheme)
@@ -539,6 +565,24 @@ func readyListenerSet(namespace string, name string) *gatewayapiv1.ListenerSet {
 			},
 		},
 	}
+}
+
+func readySharedRoutingListenerSet(hostname string) *gatewayapiv1.ListenerSet {
+	listenerSet := readyListenerSet(IstioGatewayNamespace, SharedListenerSetName(hostname))
+	listenerSet.Labels = map[string]string{
+		"app.kubernetes.io/managed-by":        "skiperator",
+		"skiperator.kartverket.no/controller": "routing-shared",
+	}
+	listenerSet.Spec.Listeners = []gatewayapiv1.ListenerEntry{{Name: "https", Hostname: gatewayHostname(hostname)}}
+	listenerSet.Status.Listeners = []gatewayapiv1.ListenerEntryStatus{
+		{
+			Name: "https",
+			Conditions: []metav1.Condition{
+				{Type: string(gatewayapiv1.ListenerConditionResolvedRefs), Status: metav1.ConditionTrue},
+			},
+		},
+	}
+	return listenerSet
 }
 
 func readyTLSSecret(namespace string, name string) *corev1.Secret {

--- a/pkg/resourcegenerator/certificate/certificate_test.go
+++ b/pkg/resourcegenerator/certificate/certificate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/internal/config"
 	"github.com/kartverket/skiperator/pkg/log"
@@ -79,6 +80,7 @@ func TestRoutingLegacyRoutingGeneratesOnlyLegacyCert(t *testing.T) {
 		Spec: skiperatorv1alpha1.RoutingSpec{
 			Hostname:        "api.example.com",
 			RoutingProvider: skiperatorv1alpha1.RoutingProviderLegacy,
+			Ownership:       skiperatorv1alpha1.RoutingOwnershipShared,
 			Routes:          []skiperatorv1alpha1.Route{{TargetApp: "backend", PathPrefix: "/", Port: 8080}},
 		},
 	}
@@ -89,4 +91,26 @@ func TestRoutingLegacyRoutingGeneratesOnlyLegacyCert(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, r.GetResources(), 1)
 	assert.Equal(t, mesh.GatewayNamespace, r.GetResources()[0].GetNamespace())
+}
+
+func TestRoutingSharedOwnershipGeneratesStandardCertInIstioGateways(t *testing.T) {
+	routing := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "API.example.COM",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+			Ownership:       skiperatorv1alpha1.RoutingOwnershipShared,
+			Routes:          []skiperatorv1alpha1.Route{{TargetApp: "backend", PathPrefix: "/", Port: 8080}},
+		},
+	}
+	r := reconciliation.NewRoutingReconciliation(context.Background(), routing, log.NewLogger(), mesh.ModeNone, nil, nil)
+	r.SetGenerateLegacyRouting(false)
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Len(t, r.GetResources(), 1)
+	certificate := r.GetResources()[0].(*certmanagerv1.Certificate)
+	assert.Equal(t, mesh.GatewayNamespace, certificate.Namespace)
+	assert.Equal(t, []string{"api.example.com"}, certificate.Spec.DNSNames)
 }

--- a/pkg/resourcegenerator/certificate/routing.go
+++ b/pkg/resourcegenerator/certificate/routing.go
@@ -44,7 +44,11 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 		r.AddResource(newCertificate(mesh.GatewayNamespace, certificateName, h.Hostname))
 	}
 	if routing.UsesStandardRouting() {
-		r.AddResource(newCertificate(routing.Namespace, certificateName, h.Hostname))
+		namespace := routing.Namespace
+		if routing.UsesSharedOwnership() {
+			namespace = mesh.GatewayNamespace
+		}
+		r.AddResource(newCertificate(namespace, certificateName, h.Hostname))
 	}
 
 	ctxLog.Debug("Finished generating certificates for routing", "routing", routing.Name)

--- a/pkg/resourcegenerator/gatewayapi/gatewayapi.go
+++ b/pkg/resourcegenerator/gatewayapi/gatewayapi.go
@@ -22,9 +22,9 @@ const (
 	httpsSectionName gatewayapiv1.SectionName = "https"
 )
 
-type unsupportedRetryOptionFunc func(field string, value string)
-
 var multiGenerator = generator.NewMulti()
+
+type unsupportedRetryOptionFunc func(field string, value string)
 
 // Generate creates Kubernetes Gateway API resources for Applications and
 // Routings that opt into the standard routing provider.
@@ -63,7 +63,7 @@ func parentListenerSetRef(namespace string, name string, section gatewayapiv1.Se
 // newListenerSet adds HTTP and HTTPS listeners for one hostname. TLS
 // termination happens on the HTTPS listener using a Secret in the same namespace
 // as the ListenerSet.
-func newListenerSet(namespace string, name string, hostname string, secretName string) *gatewayapiv1.ListenerSet {
+func newListenerSet(namespace string, name string, hostname string, secretName string, allowCrossNamespaceRoutes bool) *gatewayapiv1.ListenerSet {
 	return &gatewayapiv1.ListenerSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -71,7 +71,7 @@ func newListenerSet(namespace string, name string, hostname string, secretName s
 		},
 		Spec: gatewayapiv1.ListenerSetSpec{
 			ParentRef: parentGatewayRef(hostname),
-			Listeners: listeners(hostname, secretName),
+			Listeners: listeners(hostname, secretName, allowCrossNamespaceRoutes),
 		},
 	}
 }
@@ -96,25 +96,45 @@ func secretRef(name string) gatewayapiv1.SecretObjectReference {
 // addListenerSets creates one ListenerSet per hostname and returns the names
 // and hostnames needed when building HTTPRoutes for those listeners.
 func addListenerSets(r reconciliation.Reconciliation, namespace string, prefix string, hosts common.HostCollection, certificateName func(*common.Host) (string, error)) ([]string, []gatewayapiv1.Hostname, error) {
+	return addListenerSetsWithName(r, namespace, hosts, certificateName, func(hostname string) string {
+		return gwapi.ListenerSetName(prefix, hostname)
+	}, false)
+}
+
+// addSharedListenerSets creates one shared ListenerSet per hostname in
+// istio-gateways and returns names for HTTPRoutes in contributor namespaces.
+func addSharedListenerSets(r reconciliation.Reconciliation, hosts common.HostCollection, certificateName func(*common.Host) (string, error)) ([]string, []gatewayapiv1.Hostname, error) {
+	return addListenerSetsWithName(r, gwapi.IstioGatewayNamespace, hosts, certificateName, gwapi.SharedListenerSetName, true)
+}
+
+// addListenerSetsWithName contains common ListenerSet emission for both
+// namespace-local listeners and shared listeners in istio-gateways.
+func addListenerSetsWithName(r reconciliation.Reconciliation, namespace string, hosts common.HostCollection, certificateName func(*common.Host) (string, error), listenerSetName func(string) string, allowCrossNamespaceRoutes bool) ([]string, []gatewayapiv1.Hostname, error) {
 	listenerSetNames := make([]string, 0, hosts.Count())
 	hostnames := make([]gatewayapiv1.Hostname, 0, hosts.Count())
 
 	for _, h := range hosts.AllHosts() {
-		name := gwapi.ListenerSetName(prefix, h.Hostname)
+		name := listenerSetName(h.Hostname)
 		secretName, err := certificateName(h)
 		if err != nil {
 			return nil, nil, err
 		}
 		listenerSetNames = append(listenerSetNames, name)
 		hostnames = append(hostnames, gatewayapiv1.Hostname(h.Hostname))
-		r.AddResource(newListenerSet(namespace, name, h.Hostname, secretName))
+		r.AddResource(newListenerSet(namespace, name, h.Hostname, secretName, allowCrossNamespaceRoutes))
 	}
 	return listenerSetNames, hostnames, nil
 }
 
 // newRedirectRoute creates the HTTP listener route that sends clients to HTTPS.
 func newRedirectRoute(namespace string, prefix string, listenerSetNamespace string, listenerSetNames []string, hostnames []gatewayapiv1.Hostname) *gatewayapiv1.HTTPRoute {
-	return newHTTPRoute(namespace, gwapi.RedirectRouteName(prefix), listenerSetNamespace, listenerSetNames, httpSectionName, hostnames, []gatewayapiv1.HTTPRouteRule{redirectRule()})
+	return newRedirectRouteWithName(namespace, gwapi.RedirectRouteName(prefix), listenerSetNamespace, listenerSetNames, hostnames)
+}
+
+// newRedirectRouteWithName creates redirect routes whose names are not derived
+// from the owning object, such as shared hostname redirects.
+func newRedirectRouteWithName(namespace string, name string, listenerSetNamespace string, listenerSetNames []string, hostnames []gatewayapiv1.Hostname) *gatewayapiv1.HTTPRoute {
+	return newHTTPRoute(namespace, name, listenerSetNamespace, listenerSetNames, httpSectionName, hostnames, []gatewayapiv1.HTTPRouteRule{redirectRule()})
 }
 
 // newBackendRoute creates the HTTPS listener route that sends traffic to
@@ -144,15 +164,29 @@ func newHTTPRoute(namespace string, name string, listenerSetNamespace string, li
 
 // listeners returns the two listeners Skiperator exposes for each hostname:
 // port 80 HTTP for redirects and port 443 HTTPS for backend routes.
-func listeners(hostname string, secretName string) []gatewayapiv1.ListenerEntry {
+func listeners(hostname string, secretName string, allowCrossNamespaceRoutes bool) []gatewayapiv1.ListenerEntry {
 	terminate := gatewayapiv1.TLSModeTerminate
 
+	// On shared listeners only the HTTPS listener accepts routes from other
+	// namespaces: that is where contributing teams attach their backend routes.
+	// The HTTP listener stays same-namespace because it exists only for
+	// skiperator's own redirect route in istio-gateways; teams must not attach
+	// plain-HTTP backends and bypass TLS. Namespace-local listeners keep the
+	// default (Same) on both.
+	var httpAllowedRoutes, httpsAllowedRoutes *gatewayapiv1.AllowedRoutes
+	if allowCrossNamespaceRoutes {
+		fromAll := gatewayapiv1.NamespacesFromAll
+		fromSame := gatewayapiv1.NamespacesFromSame
+		httpsAllowedRoutes = &gatewayapiv1.AllowedRoutes{Namespaces: &gatewayapiv1.RouteNamespaces{From: &fromAll}}
+		httpAllowedRoutes = &gatewayapiv1.AllowedRoutes{Namespaces: &gatewayapiv1.RouteNamespaces{From: &fromSame}}
+	}
 	return []gatewayapiv1.ListenerEntry{
 		{
-			Name:     httpSectionName,
-			Hostname: new(gatewayapiv1.Hostname(hostname)),
-			Port:     gatewayapiv1.PortNumber(80),
-			Protocol: gatewayapiv1.HTTPProtocolType,
+			Name:          httpSectionName,
+			Hostname:      new(gatewayapiv1.Hostname(hostname)),
+			Port:          gatewayapiv1.PortNumber(80),
+			Protocol:      gatewayapiv1.HTTPProtocolType,
+			AllowedRoutes: httpAllowedRoutes,
 		},
 		{
 			Name:     httpsSectionName,
@@ -163,6 +197,7 @@ func listeners(hostname string, secretName string) []gatewayapiv1.ListenerEntry 
 				Mode:            &terminate,
 				CertificateRefs: []gatewayapiv1.SecretObjectReference{secretRef(secretName)},
 			},
+			AllowedRoutes: httpsAllowedRoutes,
 		},
 	}
 }

--- a/pkg/resourcegenerator/gatewayapi/gatewayapi_test.go
+++ b/pkg/resourcegenerator/gatewayapi/gatewayapi_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	commontypes "github.com/kartverket/skiperator/api/common"
 	"github.com/kartverket/skiperator/api/common/istiotypes"
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/kartverket/skiperator/internal/config"
@@ -116,6 +117,140 @@ func TestApplicationLegacyRoutingSkipsGatewayAPI(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Empty(t, r.GetResources())
+}
+
+func TestRoutingStandardPathRewrite(t *testing.T) {
+	routing := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "api.example.com",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+			Routes: []skiperatorv1alpha1.Route{
+				{TargetApp: "backend", PathPrefix: "/v1", RewriteUri: true, Port: 8080},
+			},
+		},
+	}
+	r := reconciliation.NewRoutingReconciliation(context.Background(), routing, log.NewLogger(), mesh.ModeNone, nil, nil)
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Len(t, r.GetResources(), 3)
+
+	listenerSet := r.GetResources()[0].(*gatewayapiv1.ListenerSet)
+	assert.Equal(t, "team-a", listenerSet.Namespace)
+	assert.Equal(t, gatewayapiv1.ObjectName(gwapi.ExternalGatewayName), listenerSet.Spec.ParentRef.Name)
+
+	redirectRoute := r.GetResources()[1].(*gatewayapiv1.HTTPRoute)
+	assert.Equal(t, gwapi.RedirectRouteName(gwapi.RoutingResourcePrefix("api")), redirectRoute.Name)
+	assert.Equal(t, httpSectionName, *redirectRoute.Spec.ParentRefs[0].SectionName)
+	assert.Equal(t, gatewayapiv1.HTTPRouteFilterRequestRedirect, redirectRoute.Spec.Rules[0].Filters[0].Type)
+
+	route := r.GetResources()[2].(*gatewayapiv1.HTTPRoute)
+	assert.Equal(t, httpsSectionName, *route.Spec.ParentRefs[0].SectionName)
+	assert.Equal(t, gatewayapiv1.HTTPRouteFilterURLRewrite, route.Spec.Rules[0].Filters[0].Type)
+	assert.Equal(t, "/v1", *route.Spec.Rules[0].Matches[0].Path.Value)
+	assert.Equal(t, gatewayapiv1.ObjectName("backend"), route.Spec.Rules[0].BackendRefs[0].Name)
+	assert.Equal(t, gatewayapiv1.PortNumber(8080), *route.Spec.Rules[0].BackendRefs[0].Port)
+}
+
+func TestRoutingLegacyRoutingSkipsGatewayAPI(t *testing.T) {
+	routing := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "api.example.com",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderLegacy,
+			Ownership:       skiperatorv1alpha1.RoutingOwnershipShared,
+			Routes: []skiperatorv1alpha1.Route{
+				{TargetApp: "backend", PathPrefix: "/v1", Port: 8080},
+			},
+		},
+	}
+	r := reconciliation.NewRoutingReconciliation(context.Background(), routing, log.NewLogger(), mesh.ModeNone, nil, nil)
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Empty(t, r.GetResources())
+}
+
+func mustNewHost(t *testing.T, hostname string) *commontypes.Host {
+	t.Helper()
+	host, err := commontypes.NewHost(hostname)
+	require.NoError(t, err)
+	return host
+}
+
+// Two Routings in different namespaces sharing one hostname must resolve to the
+// same shared certificate, so they do not flap the shared ListenerSet's cert ref.
+func TestRoutingSharedCertificateIsHostnameDerived(t *testing.T) {
+	host := mustNewHost(t, "api.kartverket.no")
+	a := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-a-routing", Namespace: "team-a"},
+		Spec:       skiperatorv1alpha1.RoutingSpec{Ownership: skiperatorv1alpha1.RoutingOwnershipShared},
+	}
+	b := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-b-routing", Namespace: "team-b"},
+		Spec:       skiperatorv1alpha1.RoutingSpec{Ownership: skiperatorv1alpha1.RoutingOwnershipShared},
+	}
+
+	aName, err := a.GetCertificateName(host)
+	require.NoError(t, err)
+	bName, err := b.GetCertificateName(host)
+	require.NoError(t, err)
+	assert.Equal(t, aName, bName)
+}
+
+func TestRoutingSharedOwnershipUsesSharedListenerSet(t *testing.T) {
+	routing := &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a"},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "API.example.COM",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+			Ownership:       skiperatorv1alpha1.RoutingOwnershipShared,
+			Routes: []skiperatorv1alpha1.Route{
+				{TargetApp: "backend", PathPrefix: "/v1", Port: 8080},
+			},
+		},
+	}
+	r := reconciliation.NewRoutingReconciliation(context.Background(), routing, log.NewLogger(), mesh.ModeNone, nil, nil)
+
+	err := Generate(r)
+
+	require.NoError(t, err)
+	require.Len(t, r.GetResources(), 3)
+
+	listenerSet := r.GetResources()[0].(*gatewayapiv1.ListenerSet)
+	assert.Equal(t, gwapi.IstioGatewayNamespace, listenerSet.Namespace)
+	assert.Equal(t, gwapi.SharedListenerSetName("api.example.com"), listenerSet.Name)
+	assert.Equal(t, "api.example.com", string(*listenerSet.Spec.Listeners[1].Hostname))
+
+	// The shared HTTPS listener accepts routes from contributor namespaces, but
+	// the HTTP listener stays same-namespace (redirect-only, no plain-HTTP
+	// backends from teams).
+	require.NotNil(t, listenerSet.Spec.Listeners[1].AllowedRoutes)
+	require.NotNil(t, listenerSet.Spec.Listeners[1].AllowedRoutes.Namespaces)
+	assert.Equal(t, gatewayapiv1.NamespacesFromAll, *listenerSet.Spec.Listeners[1].AllowedRoutes.Namespaces.From)
+	require.NotNil(t, listenerSet.Spec.Listeners[0].AllowedRoutes)
+	require.NotNil(t, listenerSet.Spec.Listeners[0].AllowedRoutes.Namespaces)
+	assert.Equal(t, gatewayapiv1.NamespacesFromSame, *listenerSet.Spec.Listeners[0].AllowedRoutes.Namespaces.From)
+	// The TLS cert ref is hostname-derived, identical across all contributors.
+	sharedCert, err := routing.GetCertificateName(mustNewHost(t, "api.example.com"))
+	require.NoError(t, err)
+	assert.Equal(t, gatewayapiv1.ObjectName(sharedCert), listenerSet.Spec.Listeners[1].TLS.CertificateRefs[0].Name)
+
+	redirectRoute := r.GetResources()[1].(*gatewayapiv1.HTTPRoute)
+	assert.Equal(t, gwapi.IstioGatewayNamespace, redirectRoute.Namespace)
+	assert.Equal(t, gwapi.SharedRedirectRouteName("api.example.com"), redirectRoute.Name)
+	assert.Nil(t, redirectRoute.Spec.ParentRefs[0].Namespace)
+	assert.Equal(t, []gatewayapiv1.Hostname{"api.example.com"}, redirectRoute.Spec.Hostnames)
+
+	route := r.GetResources()[2].(*gatewayapiv1.HTTPRoute)
+	assert.Equal(t, "team-a", route.Namespace)
+	require.NotNil(t, route.Spec.ParentRefs[0].Namespace)
+	assert.Equal(t, gatewayapiv1.Namespace(gwapi.IstioGatewayNamespace), *route.Spec.ParentRefs[0].Namespace)
+	assert.Equal(t, gatewayapiv1.ObjectName(gwapi.SharedListenerSetName("api.example.com")), route.Spec.ParentRefs[0].Name)
+	assert.Equal(t, []gatewayapiv1.Hostname{"api.example.com"}, route.Spec.Hostnames)
 }
 
 func TestApplyRetriesExpandsStringCodeShorthands(t *testing.T) {

--- a/pkg/resourcegenerator/gatewayapi/routing.go
+++ b/pkg/resourcegenerator/gatewayapi/routing.go
@@ -32,13 +32,26 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 	// Qualify the name so a standalone Routing and an equally named Application
 	// in the same namespace do not collide on Gateway API resource names.
 	routePrefix := gwapi.RoutingResourcePrefix(routing.Name)
-	listenerSetNames, hostnames, err := addListenerSets(r, routing.Namespace, routePrefix, hosts, routing.GetCertificateName)
+	var listenerSetNames []string
+	var hostnames []gatewayapiv1.Hostname
+	listenerSetNamespace := ""
+	if routing.UsesSharedOwnership() {
+		listenerSetNamespace = gwapi.IstioGatewayNamespace
+		listenerSetNames, hostnames, err = addSharedListenerSets(r, hosts, routing.GetCertificateName)
+	} else {
+		listenerSetNames, hostnames, err = addListenerSets(r, routing.Namespace, routePrefix, hosts, routing.GetCertificateName)
+	}
 	if err != nil {
 		return err
 	}
 
 	if routing.GetRedirectToHTTPS() {
-		r.AddResource(newRedirectRoute(routing.Namespace, routePrefix, "", listenerSetNames, hostnames))
+		if routing.UsesSharedOwnership() {
+			host := hosts.AllHosts()[0].Hostname
+			r.AddResource(newRedirectRouteWithName(gwapi.IstioGatewayNamespace, gwapi.SharedRedirectRouteName(host), "", listenerSetNames, hostnames))
+		} else {
+			r.AddResource(newRedirectRoute(routing.Namespace, routePrefix, listenerSetNamespace, listenerSetNames, hostnames))
+		}
 	}
 
 	rules := make([]gatewayapiv1.HTTPRouteRule, 0, len(routing.Spec.Routes))
@@ -46,7 +59,7 @@ func generateForRouting(r reconciliation.Reconciliation) error {
 		rules = append(rules, backendRule(route.TargetApp, route.TargetApp, route.Port, route.PathPrefix, route.RewriteUri))
 	}
 
-	r.AddResource(newBackendRoute(routing.Namespace, routePrefix, "", listenerSetNames, hostnames, rules))
+	r.AddResource(newBackendRoute(routing.Namespace, routePrefix, listenerSetNamespace, listenerSetNames, hostnames, rules))
 
 	ctxLog.Debug("Finished generating gateway api resources for routing", "routing", routing.Name)
 	return nil

--- a/pkg/resourcegenerator/istio/gateway/gateway_test.go
+++ b/pkg/resourcegenerator/istio/gateway/gateway_test.go
@@ -61,6 +61,7 @@ func TestRoutingLegacyRoutingGeneratesGateway(t *testing.T) {
 		Spec: skiperatorv1alpha1.RoutingSpec{
 			Hostname:        "api.example.com",
 			RoutingProvider: skiperatorv1alpha1.RoutingProviderLegacy,
+			Ownership:       skiperatorv1alpha1.RoutingOwnershipShared,
 			Routes:          []skiperatorv1alpha1.Route{{TargetApp: "backend", PathPrefix: "/", Port: 8080}},
 		},
 	}

--- a/pkg/resourcegenerator/istio/virtualservice/virtual_service_test.go
+++ b/pkg/resourcegenerator/istio/virtualservice/virtual_service_test.go
@@ -63,6 +63,7 @@ func TestRoutingLegacyRoutingGeneratesVirtualService(t *testing.T) {
 		Spec: skiperatorv1alpha1.RoutingSpec{
 			Hostname:        "api.example.com",
 			RoutingProvider: skiperatorv1alpha1.RoutingProviderLegacy,
+			Ownership:       skiperatorv1alpha1.RoutingOwnershipShared,
 			Routes:          []skiperatorv1alpha1.Route{{TargetApp: "backend", PathPrefix: "/", Port: 8080}},
 		},
 	}

--- a/pkg/resourcegenerator/resourceutils/metadata.go
+++ b/pkg/resourcegenerator/resourceutils/metadata.go
@@ -6,6 +6,7 @@ import (
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	skiperatorv1beta1 "github.com/kartverket/skiperator/api/v1beta1"
+	"github.com/kartverket/skiperator/pkg/gwapi"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -90,6 +91,17 @@ func SetRoutingLabels(object client.Object, routing *skiperatorv1alpha1.Routing)
 		labels = make(map[string]string)
 	}
 	maps.Copy(labels, routing.GetDefaultLabels())
+	object.SetLabels(labels)
+}
+
+// SetSharedRoutingLabels gives shared routing infrastructure labels that are
+// stable for all Routing objects contributing to the same hostname.
+func SetSharedRoutingLabels(object client.Object, hostname string) {
+	labels := object.GetLabels()
+	if len(labels) == 0 {
+		labels = make(map[string]string)
+	}
+	maps.Copy(labels, gwapi.SharedRoutingLabels(hostname))
 	object.SetLabels(labels)
 }
 

--- a/tests/routing/gateway-api-shared/applications.yaml
+++ b/tests/routing/gateway-api-shared/applications.yaml
@@ -1,0 +1,17 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: app-a
+  namespace: gateway-api-shared-a
+spec:
+  image: image
+  port: 8080
+---
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: app-b
+  namespace: gateway-api-shared-b
+spec:
+  image: image
+  port: 8080

--- a/tests/routing/gateway-api-shared/chainsaw-test.yaml
+++ b/tests/routing/gateway-api-shared/chainsaw-test.yaml
@@ -1,0 +1,96 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: gateway-api-shared-routing
+spec:
+  skip: false
+  concurrent: true
+  skipDelete: false
+  steps:
+    # Two Routings in different namespaces contribute to one hostname with shared
+    # ownership. Skiperator must create exactly one shared ListenerSet in
+    # istio-gateways and add the shared-routing finalizer to both contributors.
+    - try:
+        - apply:
+            file: namespaces.yaml
+        - apply:
+            file: applications.yaml
+        - apply:
+            file: routing-a.yaml
+        - apply:
+            file: routing-b.yaml
+        - script:
+            content: |
+              set -e
+              SEL="skiperator.kartverket.no/controller=routing-shared,skiperator.kartverket.no/hostname=1c53b7a99ed1939a"
+
+              wait_shared_count() {
+                want="$1"
+                for i in $(seq 1 120); do
+                  got=$(kubectl -n istio-gateways get listenerset -l "$SEL" -o name 2>/dev/null | wc -l | tr -d ' ')
+                  if [ "$got" = "$want" ]; then
+                    return 0
+                  fi
+                  sleep 1
+                done
+                echo "expected $want shared ListenerSet(s), found $got"
+                kubectl -n istio-gateways get listenerset -l "$SEL" -o wide
+                return 1
+              }
+
+              wait_has_finalizer() {
+                ns="$1"; name="$2"
+                for i in $(seq 1 60); do
+                  if kubectl -n "$ns" get routing "$name" -o jsonpath='{.metadata.finalizers}' | grep -q "shared-routing-cleanup"; then
+                    return 0
+                  fi
+                  sleep 1
+                done
+                echo "routing $ns/$name never got the shared-routing finalizer"
+                kubectl -n "$ns" get routing "$name" -o yaml
+                return 1
+              }
+
+              # One shared ListenerSet for the hostname, both contributors finalized.
+              wait_shared_count 1
+              wait_has_finalizer gateway-api-shared-a contributor-a
+              wait_has_finalizer gateway-api-shared-b contributor-b
+
+    # Deleting one contributor must NOT remove the shared resources: the other
+    # contributor still uses the hostname.
+    - try:
+        - script:
+            content: |
+              SEL="skiperator.kartverket.no/controller=routing-shared,skiperator.kartverket.no/hostname=1c53b7a99ed1939a"
+
+              kubectl -n gateway-api-shared-b delete routing contributor-b --wait=true --timeout=120s
+
+              # Give the finalizer cleanup time to (wrongly) fire, then confirm the
+              # shared ListenerSet is still present.
+              sleep 5
+              got=$(kubectl -n istio-gateways get listenerset -l "$SEL" -o name 2>/dev/null | wc -l | tr -d ' ')
+              if [ "$got" != "1" ]; then
+                echo "shared ListenerSet was removed while a contributor still exists (found $got)"
+                kubectl -n istio-gateways get listenerset -l "$SEL" -o wide
+                exit 1
+              fi
+
+    # Deleting the last contributor must remove the shared ListenerSet (and any
+    # other shared resources) from istio-gateways.
+    - try:
+        - script:
+            content: |
+              SEL="skiperator.kartverket.no/controller=routing-shared,skiperator.kartverket.no/hostname=1c53b7a99ed1939a"
+
+              kubectl -n gateway-api-shared-a delete routing contributor-a --wait=true --timeout=120s
+
+              for i in $(seq 1 120); do
+                got=$(kubectl -n istio-gateways get listenerset,httproute,certificate -l "$SEL" -o name 2>/dev/null | wc -l | tr -d ' ')
+                if [ "$got" = "0" ]; then
+                  exit 0
+                fi
+                sleep 1
+              done
+              echo "shared resources leaked after the last contributor was deleted"
+              kubectl -n istio-gateways get listenerset,httproute,certificate -l "$SEL" -o wide
+              exit 1

--- a/tests/routing/gateway-api-shared/namespaces.yaml
+++ b/tests/routing/gateway-api-shared/namespaces.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-api-shared-a
+  labels:
+    istio.io/rev: asm-stable
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-api-shared-b
+  labels:
+    istio.io/rev: asm-stable

--- a/tests/routing/gateway-api-shared/routing-a.yaml
+++ b/tests/routing/gateway-api-shared/routing-a.yaml
@@ -1,0 +1,13 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: contributor-a
+  namespace: gateway-api-shared-a
+spec:
+  hostname: shared-multi.kartverket.no
+  routingProvider: Standard
+  ownership: Shared
+  routes:
+    - pathPrefix: /team-a
+      targetApp: app-a
+      port: 8080

--- a/tests/routing/gateway-api-shared/routing-b.yaml
+++ b/tests/routing/gateway-api-shared/routing-b.yaml
@@ -1,0 +1,13 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: contributor-b
+  namespace: gateway-api-shared-b
+spec:
+  hostname: shared-multi.kartverket.no
+  routingProvider: Standard
+  ownership: Shared
+  routes:
+    - pathPrefix: /team-b
+      targetApp: app-b
+      port: 8080


### PR DESCRIPTION
Layer 9 of 9, the top of the stack. Part of the stack that replaces #884. Builds on #940.

SKIP-1682

## What this does

Several teams can now serve different path prefixes under one hostname from their own
namespaces. A Routing with `spec.ownership: Shared` contributes its paths to a shared
`ListenerSet` and `Certificate` in `istio-gateways`, and keeps its own `HTTPRoute` in
its own namespace.

## This is the only cross-namespace route attachment in the stack

Worth being precise, because two different things look similar:

- **ListenerSet to Gateway** is always cross-namespace, in every layer. Every
  ListenerSet attaches to the pre-existing `istio-external` or `istio-internal`
  Gateway in `istio-gateways`. That is baseline Gateway API, not a feature.
- **HTTPRoute to ListenerSet** is cross-namespace only here. The shared HTTPS listener
  sets `allowedRoutes.namespaces.from: All` so contributors can attach from anywhere,
  and contributor HTTPRoutes carry an explicit `istio-gateways` namespace on their
  `parentRef`.

The shared HTTP listener stays same-namespace. It exists only for Skiperator's own
redirect route, and letting teams attach plain-HTTP backends there would be a way to
bypass TLS.

No `ReferenceGrant` is involved: `backendRefs` never cross namespaces, only
`parentRefs` do, and those are governed by `allowedRoutes`.

## Cleanup, and the ordering that matters

The shared resources belong to no single Routing, so they cannot use owner references.
A ConfigMap in `istio-gateways` ref-counts the contributors per hostname, and a
finalizer removes the shared ListenerSet, redirect route and Certificate only when the
last contributor deregisters.

Registration happens **before** the shared resources are applied. A visible shared
resource can therefore never exist without a membership entry — the reverse order would
leak resources that nothing will ever clean up.

## Naming

Certificates are keyed on the hostname rather than the contributing Routing's identity,
so every contributor converges on one certificate instead of each writing a different
cert ref into the shared ListenerSet. Labels on the shared resources are
hostname-derived for the same reason.

## Conflicts

Standalone Routing objects are refused a hostname that already has a shared
ListenerSet, and shared contributors are refused overlapping path prefixes, so two
teams cannot silently claim the same path.

A `SharedRoutingResources` condition records that an object depends on resources
outside its own namespace.

## Review notes

`tests/routing/gateway-api-shared` is the end-to-end case: two Routings in two
namespaces under one hostname, then deleting one and checking the shared resources
survive until the second goes too.