### PR TITLE
Bump deps and fix security

### DIFF
--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: skiperator
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create Pull Request
         if: github.event_name == 'workflow_dispatch'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           path: skiperator
           commit-message: "Update API docs"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,4 +7,4 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
-    uses: kartverket/github-workflows/.github/workflows/auto-merge-dependabot.yml@e97ecf0919814136af78b8870c72d57f9abb419b # v4.13.1
+    uses: kartverket/github-workflows/.github/workflows/auto-merge-dependabot.yml@c3fabaec85ee208e5f10782ac71b5a82b30c6bb3 # v4.13.2

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,4 +7,4 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
-    uses: kartverket/github-workflows/.github/workflows/auto-merge-dependabot.yml@v4.13.1
+    uses: kartverket/github-workflows/.github/workflows/auto-merge-dependabot.yml@e97ecf0919814136af78b8870c72d57f9abb419b # v4.13.1

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -30,10 +30,10 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -41,7 +41,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-docker
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true
@@ -75,7 +75,7 @@ jobs:
       security-events: write
     steps:
       - name: Run Pharos
-        uses: kartverket/pharos@v0.6.4
+        uses: kartverket/pharos@e5a5cf71dd41384d6d62c7d9b387851c0457e81b # v0.6.4
         with:
           image_url: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{needs.build.outputs.image_digest}}"
           tfsec: false
@@ -87,10 +87,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Golang environment
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -98,7 +98,7 @@ jobs:
         run: make generate
 
       - name: Upload CRD and ClusterRole
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |
@@ -123,13 +123,13 @@ jobs:
           identity: skiperator
 
       - name: Checkout apps repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: kartverket/skip-apps
           token: ${{ steps.octo-sts.outputs.token }}
 
       - name: Download CRD and RBAC
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: config/

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -153,11 +153,13 @@ jobs:
           rm -rf config/
 
       - name: Commit Changes to Repo
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.event.after }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           git config --global user.email "noreply@kartverket.no"
           git config --global user.name "GitHub Actions"
-          git commit -aF- <<EOF
-          skiperator ${{ github.ref_name }}[${{ github.event.after }}]: ${{ github.event.head_commit.message }}
-          EOF
-          
+          printf 'skiperator %s[%s]: %s\n' "$REF_NAME" "$COMMIT_SHA" "$COMMIT_MESSAGE" | git commit -aF-
+
           git push

--- a/.github/workflows/check-go-generate.yaml
+++ b/.github/workflows/check-go-generate.yaml
@@ -27,10 +27,10 @@ jobs:
           contents: read
         steps:
             - name: Checkout code
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Set up Go
-              uses: actions/setup-go@v7
+              uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
               with:
                 go-version-file: go.mod
                 cache: true

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Perform dependency review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           comment-summary-in-pr: always
           fail-on-severity: moderate

--- a/.github/workflows/deploy-sandbox-dispatch.yaml
+++ b/.github/workflows/deploy-sandbox-dispatch.yaml
@@ -74,10 +74,13 @@ jobs:
           path: config/
 
       - name: Patch Image Digest
+        env:
+          IMAGE_DIGEST: ${{ github.event.inputs.image_digest }}
         run: |
           kubectl patch --type=merge --local \
             -f ${{ matrix.base_dir }}/kustomization.yaml \
-            -p '{"images":[{"name":"${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}","digest":"${{ github.event.inputs.image_digest }}"}]}' \
+            -p "$(jq -nc --arg name "$REGISTRY/$IMAGE_NAME" --arg digest "$IMAGE_DIGEST" \
+                  '{images:[{name:$name,digest:$digest}]}')" \
             -o yaml > ${{ matrix.base_dir }}/$TMP_FILE
 
           rm ${{ matrix.base_dir }}/kustomization.yaml
@@ -91,8 +94,10 @@ jobs:
           rm -rf config/
 
       - name: Commit Changes to Repo
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           git config --global user.email "noreply@kartverket.no"
           git config --global user.name "GitHub Actions"
-          git commit -am "deploy skiperator branch: ${{github.ref_name}}"
+          git commit -am "deploy skiperator branch: $REF_NAME"
           git pull --rebase && git push

--- a/.github/workflows/deploy-sandbox-dispatch.yaml
+++ b/.github/workflows/deploy-sandbox-dispatch.yaml
@@ -25,10 +25,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Golang environment
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
@@ -36,7 +36,7 @@ jobs:
         run: make generate
 
       - name: Upload CRD and ClusterRole
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |
@@ -62,13 +62,13 @@ jobs:
           identity: skiperator
 
       - name: Checkout apps repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: kartverket/skip-apps
           token: ${{ steps.octo-sts.outputs.token }}
 
       - name: Download CRD and RBAC
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: config/

--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -13,10 +13,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run golangci-lint with Reviewdog
-        uses: reviewdog/action-golangci-lint@v2
+        uses: reviewdog/action-golangci-lint@c76cceaaab89abe74e649d2e34c6c9adc26662d2 # v2.10.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review      # inline comments

--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -30,7 +30,7 @@ jobs:
       DOCKER_BUILDKIT: 1
       DOCKER_EXPERIMENTAL: 1
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -111,7 +111,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Golang environment
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -147,7 +147,7 @@ jobs:
           identity: skiperator
 
       - name: Checkout apps repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: kartverket/skip-apps
           token: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -177,11 +177,13 @@ jobs:
           rm -rf config/
 
       - name: Commit Changes to Repo
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.event.after }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           git config --global user.email "noreply@kartverket.no"
           git config --global user.name "GitHub Actions"
-          git commit -aF- <<EOF
-          skiperator ${{ github.ref_name }}[${{ github.event.after }}]: ${{ github.event.head_commit.message }}
-          EOF
+          printf 'skiperator %s[%s]: %s\n' "$REF_NAME" "$COMMIT_SHA" "$COMMIT_MESSAGE" | git commit -aF-
 
           git push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
       - name: Create test cluster

--- a/.github/workflows/upload-api-docs.yaml
+++ b/.github/workflows/upload-api-docs.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   update-docs:
     name: Update skiperator documentation in skip.kartverket.no
-    uses: kartverket/github-workflows/.github/workflows/update-skip-docs.yaml@e97ecf0919814136af78b8870c72d57f9abb419b # v4.13.1
+    uses: kartverket/github-workflows/.github/workflows/update-skip-docs.yaml@c3fabaec85ee208e5f10782ac71b5a82b30c6bb3 # v4.13.2
     with:
       source_path: "api-docs.md"
       target_path: "docs/03-applikasjon-utrulling/03-skiperator/04-api-docs.md"

--- a/.github/workflows/upload-api-docs.yaml
+++ b/.github/workflows/upload-api-docs.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   update-docs:
     name: Update skiperator documentation in skip.kartverket.no
-    uses: kartverket/github-workflows/.github/workflows/update-skip-docs.yaml@e97ecf0919814136af78b8870c72d57f9abb419b
+    uses: kartverket/github-workflows/.github/workflows/update-skip-docs.yaml@e97ecf0919814136af78b8870c72d57f9abb419b # v4.13.1
     with:
       source_path: "api-docs.md"
       target_path: "docs/03-applikasjon-utrulling/03-skiperator/04-api-docs.md"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6 AS builder
 WORKDIR /build
 
 COPY go.mod go.sum ./

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.5 AS base
+FROM --platform=$BUILDPLATFORM golang:1.26.6 AS base
 # Needed for ca-certs
 
 FROM scratch

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.93.1
 	github.com/prometheus/client_golang v1.24.1
 	github.com/r3labs/diff/v3 v3.0.2
-	github.com/stretchr/testify v1.11.1
+	github.com/stretchr/testify v1.12.0
 	go.uber.org/zap v1.28.0
-	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
+	google.golang.org/protobuf v1.36.12
 	istio.io/api v1.30.3
 	istio.io/client-go v1.30.3
 	k8s.io/api v0.36.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kartverket/skiperator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cert-manager/cert-manager v1.21.1

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
+github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
@@ -608,8 +608,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
 google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
-google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
-google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
+google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- Pin GitHub Actions and reusable workflows to immutable commits.
- Update Go base images and language version to 1.26.6.
- Update `testify` to 1.12.0.
- Replace the `protobuf` pseudo-version with 1.36.12.
- Improve deployment commit and patch generation in GitHub Actions workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->