### PR TITLE
fix(routing): guard shared hostnames against contributor divergence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ LOCAL_WEBHOOK_CERTS_DIR    := $(shell mktemp -d -t skiperator-webhook-certs.XXXX
 WEBHOOK_HOST                = 0.0.0.0
 WEBHOOK_ARGS                = --webhook-cert-dir=$(LOCAL_WEBHOOK_CERTS_DIR) --webhook-host=$(WEBHOOK_HOST)
 SKIPJOB_CRD_FILE            ?= config/crd/skiperator.kartverket.no_skipjobs.yaml
+# Pinned by digest so local runs and the api-docs workflow render identically.
+CRDOC_IMAGE                ?= ghcr.io/fybrik/crdoc@sha256:355ef777a45021ee864e613b2234b4f2c6193762e3e0de94a26b66d06cec81c3
+CRDOC_RESOURCES_DIR        := crdoc-resources
 
 .PHONY: ensure-kubectl
 ensure-kubectl:
@@ -47,6 +50,7 @@ ensure-kubectl:
 generate:
 	go generate ./...
 	@$(MAKE) patch-skipjob-crd SKIPJOB_CRD_FILE=$(SKIPJOB_CRD_FILE)
+	@$(MAKE) apidocs
 
 .PHONY: patch-skipjob-crd
 patch-skipjob-crd: ensure-kubectl
@@ -61,6 +65,20 @@ patch-skipjob-crd: ensure-kubectl
 	awk 'NR==1 && $$0!="---"{print "---"} {print}' "$$tmp_file" > "$$normalized_file"; \
 	rm -f "$$tmp_file"; \
 	mv "$$normalized_file" "$(SKIPJOB_CRD_FILE)"
+
+# Renders api-docs.md from the generated CRDs. crdoc only reads the directory it
+# is pointed at, so the CRDs are staged in one and removed again afterwards.
+.PHONY: apidocs
+apidocs:
+	@mkdir -p $(CRDOC_RESOURCES_DIR)
+	@cp config/crd/skiperator.kartverket.no_*.yaml $(CRDOC_RESOURCES_DIR)/
+	@docker run -u $$(id -u):$$(id -g) --rm -v "$(PWD)":/workdir $(CRDOC_IMAGE) \
+		--resources /workdir/$(CRDOC_RESOURCES_DIR) \
+		--output /workdir/api-docs.md \
+		--template /workdir/.github/crdoc.tmpl; \
+	status=$$?; \
+	rm -rf $(CRDOC_RESOURCES_DIR); \
+	exit $$status
 
 .PHONY: build
 build: generate

--- a/api-docs.md
+++ b/api-docs.md
@@ -4390,7 +4390,7 @@ Status
         <td><b>redirectToHTTPS</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          RedirectToHTTPS applies per hostname rather than per contributor. With<br/>ownership=Shared the redirect route is itself a shared resource: the first<br/>contributor asking for it creates it for the whole hostname, and no<br/>contributor removes it again. Setting this to false has no effect while<br/>another contributor on the same hostname keeps it enabled.<br/>
           <br/>
             <i>Default</i>: `true`<br/>
         </td>

--- a/api/common/status_types.go
+++ b/api/common/status_types.go
@@ -46,6 +46,7 @@ const (
 	StandardRoutingReadyConditionType = "StandardRoutingReady"
 	LegacyRoutingActiveConditionType  = "LegacyRoutingActive"
 	SharedRoutingResourcesType        = "SharedRoutingResources"
+	RoutePathConflictType             = "RoutePathConflict"
 
 	// MigrationStalledReason is the condition reason written when a Gateway API
 	// migration has kept legacy routing active past the deadline. Shared so the
@@ -70,6 +71,7 @@ var conditionOrder = map[string]int{
 	LegacyRoutingActiveConditionType:  6,
 	StandardRoutingReadyConditionType: 7,
 	SharedRoutingResourcesType:        8,
+	RoutePathConflictType:             9,
 }
 
 // SortConditions orders Conditions canonically (see conditionOrder), so the
@@ -163,6 +165,12 @@ func (s *SkiperatorStatus) SetLegacyRoutingActiveCondition(status metav1.Conditi
 // shared Gateway API listener, redirect, and certificate resources.
 func (s *SkiperatorStatus) SetSharedRoutingResourcesCondition(status metav1.ConditionStatus, observedGeneration int64, reason string, message string) {
 	s.setCondition(SharedRoutingResourcesType, status, observedGeneration, reason, message)
+}
+
+// SetRoutePathConflictCondition records that another accepted HTTPRoute on the
+// same hostname overlaps one of this object's path prefixes.
+func (s *SkiperatorStatus) SetRoutePathConflictCondition(status metav1.ConditionStatus, observedGeneration int64, reason string, message string) {
+	s.setCondition(RoutePathConflictType, status, observedGeneration, reason, message)
 }
 
 func (s *SkiperatorStatus) AddSubResourceStatus(object client.Object, message string, status StatusNames) {

--- a/api/v1alpha1/routing_types.go
+++ b/api/v1alpha1/routing_types.go
@@ -38,6 +38,7 @@ type Routing struct {
 
 // +kubebuilder:object:generate=true
 // +kubebuilder:validation:XValidation:rule="!has(self.ownership) || self.ownership != 'Shared' || self.routingProvider == 'Standard'",message="spec.ownership=Shared requires spec.routingProvider=Standard"
+// +kubebuilder:validation:XValidation:rule="!has(self.ownership) || self.ownership != 'Shared' || !self.hostname.contains('+')",message="spec.ownership=Shared cannot use a custom certificate secret; the certificate is shared per hostname"
 // +kubebuilder:validation:XValidation:rule="self.hostname == oldSelf.hostname",message="spec.hostname is immutable"
 type RoutingSpec struct {
 	//+kubebuilder:validation:Required

--- a/api/v1alpha1/routing_types.go
+++ b/api/v1alpha1/routing_types.go
@@ -63,6 +63,11 @@ type RoutingSpec struct {
 	//+kubebuilder:validation:Required
 	Routes []Route `json:"routes"`
 
+	// RedirectToHTTPS applies per hostname rather than per contributor. With
+	// ownership=Shared the redirect route is itself a shared resource: the first
+	// contributor asking for it creates it for the whole hostname, and no
+	// contributor removes it again. Setting this to false has no effect while
+	// another contributor on the same hostname keeps it enabled.
 	//+kubebuilder:validation:Optional
 	//+kubebuilder:default:=true
 	RedirectToHTTPS *bool `json:"redirectToHTTPS,omitempty"`

--- a/config/crd/skiperator.kartverket.no_routings.yaml
+++ b/config/crd/skiperator.kartverket.no_routings.yaml
@@ -62,6 +62,12 @@ spec:
                 type: string
               redirectToHTTPS:
                 default: true
+                description: |-
+                  RedirectToHTTPS applies per hostname rather than per contributor. With
+                  ownership=Shared the redirect route is itself a shared resource: the first
+                  contributor asking for it creates it for the whole hostname, and no
+                  contributor removes it again. Setting this to false has no effect while
+                  another contributor on the same hostname keeps it enabled.
                 type: boolean
               routes:
                 items:

--- a/config/crd/skiperator.kartverket.no_routings.yaml
+++ b/config/crd/skiperator.kartverket.no_routings.yaml
@@ -100,6 +100,9 @@ spec:
             - message: spec.ownership=Shared requires spec.routingProvider=Standard
               rule: '!has(self.ownership) || self.ownership != ''Shared'' || self.routingProvider
                 == ''Standard'''
+            - message: spec.ownership=Shared cannot use a custom certificate secret;
+                the certificate is shared per hostname
+              rule: '!has(self.ownership) || self.ownership != ''Shared'' || !self.hostname.contains(''+'')'
             - message: spec.hostname is immutable
               rule: self.hostname == oldSelf.hostname
           status:

--- a/internal/controllers/common/util.go
+++ b/internal/controllers/common/util.go
@@ -153,6 +153,24 @@ func SetSharedRoutingResourcesActive(obj common.SKIPObject) {
 	)
 }
 
+// SetRoutePathConflict marks that this object's paths overlap another accepted
+// route on the same hostname. Gateway API has already decided which route
+// answers a request, so the condition reports the overlap instead of blocking
+// the reconcile.
+func SetRoutePathConflict(obj common.SKIPObject, message string) {
+	obj.GetStatus().SetRoutePathConflictCondition(
+		metav1.ConditionTrue,
+		obj.GetGeneration(),
+		"OverlappingPathPrefix",
+		message,
+	)
+}
+
+// ClearRoutePathConflictCondition drops the condition when no overlap remains.
+func ClearRoutePathConflictCondition(obj common.SKIPObject) {
+	meta.RemoveStatusCondition(&obj.GetStatus().Conditions, common.RoutePathConflictType)
+}
+
 // ClearSharedRoutingResourcesCondition drops the condition, so a standalone
 // object does not carry one.
 func ClearSharedRoutingResourcesCondition(obj common.SKIPObject) {

--- a/internal/controllers/routing.go
+++ b/internal/controllers/routing.go
@@ -41,6 +41,11 @@ import (
 // resources in istio-gateways, which are not owned by any single contributor.
 const sharedRoutingFinalizer = "skiperator.kartverket.no/shared-routing-cleanup"
 
+// finalizerRequeueDelay is how long to wait before reconciling a Routing whose
+// finalizer was just written. Short enough to be invisible, long enough for the
+// cache to have caught up with the write.
+const finalizerRequeueDelay = time.Second
+
 // +kubebuilder:rbac:groups=skiperator.kartverket.no,resources=routings;routings/status,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=skiperator.kartverket.no,resources=applications;applications/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
@@ -312,13 +317,15 @@ func (r *RoutingReconciler) reconcileSharedRoutingFinalizer(ctx context.Context,
 
 	hasFinalizer := ctrlutil.ContainsFinalizer(routing, sharedRoutingFinalizer)
 	// Add the finalizer for shared routings, remove it if a Routing switched away
-	// from shared ownership. Requeue so the rest of the reconcile runs cleanly.
+	// from shared ownership. Writing the finalizer leaves the generation
+	// untouched, so the event filter drops the resulting update and the requeue
+	// below is what runs the rest of the reconcile.
 	if routing.UsesSharedOwnership() && !hasFinalizer {
 		ctrlutil.AddFinalizer(routing, sharedRoutingFinalizer)
 		if err := r.GetClient().Update(ctx, routing); err != nil {
 			return true, reconcile.Result{}, err
 		}
-		return true, reconcile.Result{Requeue: true}, nil
+		return true, reconcile.Result{RequeueAfter: finalizerRequeueDelay}, nil
 	}
 	if !routing.UsesSharedOwnership() && hasFinalizer {
 		// Switched away from shared ownership: release membership so the shared
@@ -330,7 +337,7 @@ func (r *RoutingReconciler) reconcileSharedRoutingFinalizer(ctx context.Context,
 		if err := r.GetClient().Update(ctx, routing); err != nil {
 			return true, reconcile.Result{}, err
 		}
-		return true, reconcile.Result{Requeue: true}, nil
+		return true, reconcile.Result{RequeueAfter: finalizerRequeueDelay}, nil
 	}
 	return false, reconcile.Result{}, nil
 }

--- a/internal/controllers/routing.go
+++ b/internal/controllers/routing.go
@@ -229,6 +229,7 @@ func (r *RoutingReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	finalizeRoutingStatus(&r.ReconcilerBase, routing, routingState, "Routing has been reconciled")
 	if routing.UsesStandardRouting() {
 		setSharedRoutingResourcesCondition(routing)
+		r.setRoutePathConflictCondition(ctx, routing, rLog)
 	}
 	r.UpdateStatus(ctx, routing)
 	if routing.UsesStandardRouting() && !routingState.Readiness.Ready {
@@ -246,6 +247,26 @@ func setSharedRoutingResourcesCondition(routing *skiperatorv1alpha1.Routing) {
 		return
 	}
 	common.ClearSharedRoutingResourcesCondition(routing)
+}
+
+// setRoutePathConflictCondition reports overlaps Gateway API has already
+// resolved. Two Routings applied close together both pass validation, and from
+// then on Gateway API picks which one answers a request without telling either
+// team. The condition and its event are how they find out. A failed lookup
+// keeps the previous condition, because "could not check" is not the same
+// answer as "no conflict".
+func (r *RoutingReconciler) setRoutePathConflictCondition(ctx context.Context, routing *skiperatorv1alpha1.Routing, rLog log.Logger) {
+	conflict, err := gwapi.DetectRoutingPathConflict(ctx, r.GetClient(), routing)
+	if err != nil {
+		rLog.Error(err, "failed to check for overlapping route paths")
+		return
+	}
+	if conflict == nil {
+		common.ClearRoutePathConflictCondition(routing)
+		return
+	}
+	common.SetRoutePathConflict(routing, conflict.Message())
+	r.EmitWarningEvent(routing, "RoutePathConflict", conflict.Message())
 }
 
 func (r *RoutingReconciler) getRouting(ctx context.Context, req reconcile.Request) (*skiperatorv1alpha1.Routing, error) {

--- a/pkg/gwapi/conflicts.go
+++ b/pkg/gwapi/conflicts.go
@@ -3,10 +3,12 @@ package gwapi
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -45,6 +47,18 @@ func validateApplicationConflicts(ctx context.Context, c client.Client, applicat
 	return nil
 }
 
+// RoutePathConflict is an overlap between one of a Routing's path prefixes and
+// an accepted HTTPRoute belonging to another Routing on the same hostname.
+type RoutePathConflict struct {
+	Hostname   string
+	PathPrefix string
+	Route      types.NamespacedName
+}
+
+func (c RoutePathConflict) Message() string {
+	return fmt.Sprintf("path %q on hostname %q overlaps accepted HTTPRoute %s, so Gateway API decides per request which of the two serves it", c.PathPrefix, c.Hostname, c.Route)
+}
+
 // validateRoutingConflicts enforces first-accepted-route-wins for shared
 // hostnames.
 //
@@ -52,6 +66,14 @@ func validateApplicationConflicts(ctx context.Context, c client.Client, applicat
 // predictable. Skiperator refuses overlapping path prefixes only when the
 // existing HTTPRoute is already accepted by Gateway API. Redirect-only routes
 // are ignored because they do not claim a backend path.
+//
+// The exception is a path this Routing is already serving. Two Routings applied
+// close together both pass validation, and once Gateway API accepts them the
+// overlap exists whatever Skiperator does. Refusing the reconcile then hands the
+// path to nobody and only stops this Routing from converging, so the overlap is
+// reported through DetectRoutingPathConflict instead. Claiming a new path over
+// an accepted route is still refused, including from a Routing that already
+// serves other paths on the hostname.
 func validateRoutingConflicts(ctx context.Context, c client.Client, routing *skiperatorv1alpha1.Routing) error {
 	if !routing.UsesStandardRouting() {
 		return nil
@@ -64,26 +86,94 @@ func validateRoutingConflicts(ctx context.Context, c client.Client, routing *ski
 	if err := validateRoutingHostnameOwnership(ctx, c, routing, host.Hostname); err != nil {
 		return err
 	}
+	conflict, alreadyServing, err := findRoutingPathConflict(ctx, c, routing, host.Hostname)
+	if err != nil {
+		return err
+	}
+	if conflict == nil || alreadyServing {
+		return nil
+	}
+	return fmt.Errorf("path %q on hostname %q conflicts with accepted HTTPRoute %s", conflict.PathPrefix, conflict.Hostname, conflict.Route)
+}
+
+// DetectRoutingPathConflict reports the overlap that validateRoutingConflicts
+// lets through. Gateway API has already picked which route answers a request,
+// and it tells neither team, so this is what the contributors have to go on.
+func DetectRoutingPathConflict(ctx context.Context, c client.Client, routing *skiperatorv1alpha1.Routing) (*RoutePathConflict, error) {
+	if !routing.UsesStandardRouting() {
+		return nil, nil
+	}
+	hosts, err := routing.Hostnames()
+	if err != nil {
+		return nil, err
+	}
+	conflict, _, err := findRoutingPathConflict(ctx, c, routing, hosts.AllHosts()[0].Hostname)
+	return conflict, err
+}
+
+// findRoutingPathConflict returns the first overlap between routing's paths and
+// another Routing's accepted route on hostname. The second return says whether
+// routing's own accepted route already carries the conflicting path, which is
+// what separates a live overlap from a new claim on someone else's path.
+func findRoutingPathConflict(ctx context.Context, c client.Client, routing *skiperatorv1alpha1.Routing, hostname string) (*RoutePathConflict, bool, error) {
 	routes := &gatewayapiv1.HTTPRouteList{}
 	if err := c.List(ctx, routes); err != nil {
-		return fmt.Errorf("failed to list Gateway API HTTPRoutes: %w", err)
+		return nil, false, fmt.Errorf("failed to list Gateway API HTTPRoutes: %w", err)
 	}
+
+	var conflict *RoutePathConflict
+	servedPaths := []string{}
 	for _, existing := range routes.Items {
-		if !skiperatorManaged(existing.Labels) || sameRouting(existing.Labels, routing) || !routeAccepted(existing) || isRedirectRoute(existing) {
+		if !skiperatorManaged(existing.Labels) || isRedirectRoute(existing) || !routeHasHostname(existing, hostname) {
 			continue
 		}
-		if !routeHasHostname(existing, host.Hostname) {
+		if sameRouting(existing.Labels, routing) {
+			if routeAccepted(existing) {
+				servedPaths = append(servedPaths, routePathPrefixes(existing)...)
+			}
 			continue
 		}
-		for _, existingRule := range existing.Spec.Rules {
-			for _, newRoute := range routing.Spec.Routes {
-				if routeRuleOverlaps(existingRule, newRoute.PathPrefix) {
-					return fmt.Errorf("path %q on hostname %q conflicts with accepted HTTPRoute %s/%s", newRoute.PathPrefix, host.Hostname, existing.Namespace, existing.Name)
-				}
+		if conflict != nil || !routeAccepted(existing) {
+			continue
+		}
+		if pathPrefix, overlaps := overlappingPathPrefix(existing, routing); overlaps {
+			conflict = &RoutePathConflict{
+				Hostname:   hostname,
+				PathPrefix: pathPrefix,
+				Route:      types.NamespacedName{Namespace: existing.Namespace, Name: existing.Name},
 			}
 		}
 	}
-	return nil
+	if conflict == nil {
+		return nil, false, nil
+	}
+	return conflict, slices.Contains(servedPaths, conflict.PathPrefix), nil
+}
+
+// overlappingPathPrefix returns the first path prefix in routing's spec that
+// collides with a rule on existing.
+func overlappingPathPrefix(existing gatewayapiv1.HTTPRoute, routing *skiperatorv1alpha1.Routing) (string, bool) {
+	for _, rule := range existing.Spec.Rules {
+		for _, route := range routing.Spec.Routes {
+			if routeRuleOverlaps(rule, route.PathPrefix) {
+				return route.PathPrefix, true
+			}
+		}
+	}
+	return "", false
+}
+
+// routePathPrefixes lists the path prefixes a live HTTPRoute matches on.
+func routePathPrefixes(route gatewayapiv1.HTTPRoute) []string {
+	prefixes := []string{}
+	for _, rule := range route.Spec.Rules {
+		for _, match := range rule.Matches {
+			if match.Path != nil && match.Path.Value != nil {
+				prefixes = append(prefixes, *match.Path.Value)
+			}
+		}
+	}
+	return prefixes
 }
 
 // validateRoutingHostnameOwnership prevents standalone Routing from attaching

--- a/pkg/gwapi/conflicts_test.go
+++ b/pkg/gwapi/conflicts_test.go
@@ -1,9 +1,16 @@
 package gwapi
 
 import (
+	"context"
 	"testing"
 
+	skiperatorv1alpha1 "github.com/kartverket/skiperator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -42,4 +49,107 @@ func routeRule(path string) gatewayapiv1.HTTPRouteRule {
 			},
 		},
 	}
+}
+
+// Two Routings applied close together both pass validation, because neither
+// route is accepted yet when the other is checked. Once Gateway API accepts
+// them the overlap is real and live, so it has to be reported rather than
+// turned into an error state that stops a serving Routing from converging.
+func TestRoutingPathConflictReportedOnceOwnRouteIsAccepted(t *testing.T) {
+	ctx := context.Background()
+	routing := sharedRouting("team-b", "ns-b", "/api/v1")
+
+	t.Run("own route not accepted yet: refuse the claim", func(t *testing.T) {
+		c := conflictClient(t, acceptedRoute("team-a", "ns-a", "/api"))
+		require.ErrorContains(t, validateRoutingConflicts(ctx, c, routing), `path "/api/v1" on hostname "shared.example.com" conflicts with accepted HTTPRoute ns-a/team-a`)
+	})
+
+	t.Run("already serving the path: report instead of blocking", func(t *testing.T) {
+		c := conflictClient(t, acceptedRoute("team-a", "ns-a", "/api"), ownAcceptedRoute(routing, "/api/v1"))
+		require.NoError(t, validateRoutingConflicts(ctx, c, routing))
+
+		conflict, err := DetectRoutingPathConflict(ctx, c, routing)
+		require.NoError(t, err)
+		require.NotNil(t, conflict)
+		assert.Equal(t, "/api/v1", conflict.PathPrefix)
+		assert.Equal(t, "ns-a/team-a", conflict.Route.String())
+	})
+
+	t.Run("accepted on another path: a new claim is still refused", func(t *testing.T) {
+		c := conflictClient(t, acceptedRoute("team-a", "ns-a", "/api"), ownAcceptedRoute(routing, "/team-b"))
+		require.ErrorContains(t, validateRoutingConflicts(ctx, c, routing), `conflicts with accepted HTTPRoute ns-a/team-a`)
+	})
+
+	t.Run("no overlap: no conflict", func(t *testing.T) {
+		c := conflictClient(t, acceptedRoute("team-a", "ns-a", "/other"), ownAcceptedRoute(routing, "/api/v1"))
+		require.NoError(t, validateRoutingConflicts(ctx, c, routing))
+
+		conflict, err := DetectRoutingPathConflict(ctx, c, routing)
+		require.NoError(t, err)
+		assert.Nil(t, conflict)
+	})
+}
+
+func conflictClient(t *testing.T, routes ...*gatewayapiv1.HTTPRoute) client.Client {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, gatewayapiv1.Install(s))
+	builder := fake.NewClientBuilder().WithScheme(s)
+	for _, route := range routes {
+		builder = builder.WithObjects(route)
+	}
+	return builder.Build()
+}
+
+func sharedRouting(name string, namespace string, pathPrefix string) *skiperatorv1alpha1.Routing {
+	return &skiperatorv1alpha1.Routing{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: skiperatorv1alpha1.RoutingSpec{
+			Hostname:        "shared.example.com",
+			RoutingProvider: skiperatorv1alpha1.RoutingProviderStandard,
+			Ownership:       skiperatorv1alpha1.RoutingOwnershipShared,
+			Routes:          []skiperatorv1alpha1.Route{{PathPrefix: pathPrefix, TargetApp: name}},
+		},
+	}
+}
+
+func acceptedRoute(name string, namespace string, pathPrefix string) *gatewayapiv1.HTTPRoute {
+	return &gatewayapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by":              "skiperator",
+				"skiperator.kartverket.no/controller":       "routing",
+				"skiperator.kartverket.no/routing-name":     name,
+				"skiperator.kartverket.no/source-namespace": namespace,
+			},
+		},
+		Spec: gatewayapiv1.HTTPRouteSpec{
+			Hostnames: []gatewayapiv1.Hostname{"shared.example.com"},
+			Rules:     []gatewayapiv1.HTTPRouteRule{backendRule(routeRule(pathPrefix))},
+		},
+		Status: gatewayapiv1.HTTPRouteStatus{
+			RouteStatus: gatewayapiv1.RouteStatus{
+				Parents: []gatewayapiv1.RouteParentStatus{{
+					Conditions: []metav1.Condition{{
+						Type:   string(gatewayapiv1.RouteConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: "Accepted",
+					}},
+				}},
+			},
+		},
+	}
+}
+
+func ownAcceptedRoute(routing *skiperatorv1alpha1.Routing, pathPrefix string) *gatewayapiv1.HTTPRoute {
+	return acceptedRoute(routing.Name, routing.Namespace, pathPrefix)
+}
+
+// backendRule turns a match-only rule into one that claims a backend, so it is
+// not skipped as a redirect-only route.
+func backendRule(rule gatewayapiv1.HTTPRouteRule) gatewayapiv1.HTTPRouteRule {
+	rule.BackendRefs = []gatewayapiv1.HTTPBackendRef{{}}
+	return rule
 }

--- a/tests/routing/gateway-api-shared/chainsaw-test.yaml
+++ b/tests/routing/gateway-api-shared/chainsaw-test.yaml
@@ -56,6 +56,60 @@ spec:
               wait_has_finalizer gateway-api-shared-a contributor-a
               wait_has_finalizer gateway-api-shared-b contributor-b
 
+    # One contributor must not be able to take over a path another contributor is
+    # already serving. Team B is accepted on /team-b, then tries to also claim
+    # team A's /team-a: Skiperator refuses the claim, and B's HTTPRoute keeps
+    # serving only its own path.
+    - try:
+        - script:
+            content: |
+              wait_route_accepted() {
+                ns="$1"; name="$2"
+                for i in $(seq 1 120); do
+                  accepted=$(kubectl -n "$ns" get httproute "$name" -o jsonpath='{range .status.parents[*]}{range .conditions[?(@.type=="Accepted")]}{.status}{"\n"}{end}{end}' | grep -c '^True$' || true)
+                  if [ "$accepted" -ge 1 ]; then
+                    return 0
+                  fi
+                  sleep 1
+                done
+                echo "httproute $ns/$name was never accepted"
+                kubectl -n "$ns" get httproute "$name" -o yaml
+                return 1
+              }
+
+              wait_route_accepted gateway-api-shared-a contributor-a-routing
+              wait_route_accepted gateway-api-shared-b contributor-b-routing
+
+              kubectl -n gateway-api-shared-b patch routing contributor-b --type=merge \
+                -p '{"spec":{"routes":[{"pathPrefix":"/team-b","targetApp":"app-b","port":8080},{"pathPrefix":"/team-a","targetApp":"app-b","port":8080}]}}'
+
+              for i in $(seq 1 60); do
+                summary=$(kubectl -n gateway-api-shared-b get routing contributor-b -o jsonpath='{.status.summary.message}')
+                case "$summary" in
+                  *"conflicts with accepted HTTPRoute"*) break ;;
+                esac
+                if [ "$i" -eq 60 ]; then
+                  echo "contributor-b was allowed to claim team A's path: $summary"
+                  kubectl -n gateway-api-shared-b get routing contributor-b -o yaml
+                  exit 1
+                fi
+                sleep 1
+              done
+
+              paths=$(kubectl -n gateway-api-shared-b get httproute contributor-b-routing -o jsonpath='{.spec.rules[*].matches[*].path.value}')
+              case "$paths" in
+                *"/team-a"*)
+                  echo "contributor-b's HTTPRoute picked up team A's path: $paths"
+                  kubectl -n gateway-api-shared-b get httproute contributor-b-routing -o yaml
+                  exit 1
+                  ;;
+              esac
+
+              # Hand team B back its own spec so the deletion steps below start
+              # from a healthy pair.
+              kubectl -n gateway-api-shared-b patch routing contributor-b --type=merge \
+                -p '{"spec":{"routes":[{"pathPrefix":"/team-b","targetApp":"app-b","port":8080}]}}'
+
     # Deleting one contributor must NOT remove the shared resources: the other
     # contributor still uses the hostname.
     - try:

--- a/tests/routing/gateway-api-shared/chainsaw-test.yaml
+++ b/tests/routing/gateway-api-shared/chainsaw-test.yaml
@@ -94,3 +94,18 @@ spec:
               echo "shared resources leaked after the last contributor was deleted"
               kubectl -n istio-gateways get listenerset,httproute,certificate -l "$SEL" -o wide
               exit 1
+
+    # A shared contributor must not bring its own certificate: the hostname's
+    # certificate is shared, so a custom secret would rewrite the shared
+    # ListenerSet's certificateRef out from under every other contributor.
+    - try:
+        - script:
+            content: |
+              out=$(kubectl apply -f routing-custom-cert.yaml 2>&1) && {
+                echo "custom certificate secret was accepted on a shared Routing"
+                exit 1
+              }
+              echo "$out" | grep -q "cannot use a custom certificate secret" || {
+                echo "rejected for the wrong reason: $out"
+                exit 1
+              }

--- a/tests/routing/gateway-api-shared/routing-custom-cert.yaml
+++ b/tests/routing/gateway-api-shared/routing-custom-cert.yaml
@@ -1,0 +1,13 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Routing
+metadata:
+  name: contributor-custom-cert
+  namespace: gateway-api-shared-a
+spec:
+  hostname: shared-multi.kartverket.no+custom-tls
+  routingProvider: Standard
+  ownership: Shared
+  routes:
+    - pathPrefix: /team-c
+      targetApp: app-a
+      port: 8080


### PR DESCRIPTION
Layer 10, on top of the stack. Part of the stack that replaces #884. Builds on #941.

SKIP-1682, SKIP-1313

## What this does

Follow-ups from asking what #941 does when four or fifteen teams share a hostname
rather than two. The ref-counting and cleanup hold up at any number of
contributors, so nothing here reshapes that layer. What the review turned up was
divergence between contributors: fields that are per-Routing in the API but
per-hostname in the resources they generate.

Layers 1 to 9 are untouched.

## A custom certificate is refused on a shared hostname

`GetCertificateName` checks `host.UsesCustomCert()` before the shared branch, and
`SharedListenerSetName` hashes only the host part of the hostname. A contributor
writing `hostname: api.example.com+team-tls` therefore lands on the same shared
ListenerSet as everyone else while generating a different `certificateRef`.

That is not one team getting an odd certificate. Every contributor rewrites the
shared listener on each reconcile, TLS for the hostname flips between certificates,
and one of the two names a secret that does not exist in `istio-gateways`. A CEL
rule now refuses the combination at admission. Standalone Routings keep custom
certificates, since they own their hostname.

## Path overlaps are reported rather than resolved in silence

`validateRoutingConflicts` only compared against HTTPRoutes Gateway API had already
accepted, so two Routings applied close together both pass: when each is validated,
the other route is not accepted yet. Once both are accepted, Gateway API decides
which one answers a request and tells neither team.

Erroring at that point helps nobody, since the routes exist and traffic is already
flowing. Skiperator now sets a `RoutePathConflict` condition and emits a warning
event on the Routings involved, and still refuses a *new* claim on an accepted path.
That distinction is narrower than "this Routing has no accepted route": a
contributor accepted on `/team-b` that edits its spec to also claim a peer's
`/team-a` is making a new claim and is refused. The exception covers only a path
the Routing's own accepted route already carries.

Which of two overlapping routes wins is left to Gateway API rather than recomputed
here, so both sides get the condition.

## Smaller things

`redirectToHTTPS` is documented as per-hostname under shared ownership: the first
contributor asking for the redirect creates it for everyone, and setting the field
to false changes nothing while a peer still wants it.

`reconcile.Result{Requeue: true}` on the shared-finalizer path is deprecated, and
both uses came from #941, so they read as new findings on that PR.

A `make apidocs` target renders `api-docs.md` with the same digest-pinned crdoc
image the workflow uses, invoked from `generate` after the SKIPJob CRD is patched.
`make build` now needs Docker, which is already true for running the tests.

## Testing

`tests/routing/gateway-api-shared` gains two cases: a shared Routing carrying a
custom certificate secret is rejected, and a contributor already serving `/team-b`
is refused when it tries to also claim `/team-a`, with its HTTPRoute left untouched.
The suite passes locally.

The path-grab case was checked against a deliberately broken operator, built with
the new guard disabled, where it fails with `contributor-b was allowed to claim team
A's path: All subresources synced`. Unit tests in `pkg/gwapi` cover the three states
of the conflict scan directly.

`golangci-lint run --new-from-rev=main` reports no findings.

Note for anyone running the suite locally: `go tool chainsaw` panics on startup
under Go 1.27 (`kind Configuration not found in chainsaw.kyverno.io/v1alpha2`) and
works under Go 1.26, which is what `go.mod` asks for. Unrelated to this PR.
