### PR TITLE
fix image-building without docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,13 @@ patch-skipjob-crd: ensure-kubectl
 # is pointed at, so the CRDs are staged in one and removed again afterwards.
 .PHONY: apidocs
 apidocs:
-	@mkdir -p $(CRDOC_RESOURCES_DIR)
-	@cp config/crd/skiperator.kartverket.no_*.yaml $(CRDOC_RESOURCES_DIR)/
-	@docker run -u $$(id -u):$$(id -g) --rm -v "$(PWD)":/workdir $(CRDOC_IMAGE) \
+	@if ! command -v docker >/dev/null 2>&1; then \
+		echo "docker not found on PATH, skipping apidocs"; \
+		exit 0; \
+	fi; \
+	mkdir -p $(CRDOC_RESOURCES_DIR) || exit 1; \
+	cp config/crd/skiperator.kartverket.no_*.yaml $(CRDOC_RESOURCES_DIR)/ || exit 1; \
+	docker run -u $$(id -u):$$(id -g) --rm -v "$(PWD)":/workdir $(CRDOC_IMAGE) \
 		--resources /workdir/$(CRDOC_RESOURCES_DIR) \
 		--output /workdir/api-docs.md \
 		--template /workdir/.github/crdoc.tmpl; \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changed

- Fixed the `apidocs` Make target for environments without Docker.
- The target now exits successfully when Docker is unavailable.
- Added explicit error handling for resource-directory creation, CRD copying, and Docker execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->